### PR TITLE
Convert eLife padding mixin for Libero

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -147,8 +147,8 @@ gulp.task('exportPatterns', ['build', 'patternsExport:clean'], () => {
 
 });
 
-gulp.task('sass:watch', () => {
-  gulp.watch([config.files.src.sass, config.files.test.sass], ['css:generate'] );
+gulp.task('sass:watch', ['css:generate'], () => {
+  gulp.watch([config.files.src.sass, config.files.test.sass], ['css:generate']);
 });
 
 gulp.task('default', ['exportPatterns']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ const sourcemaps = require('gulp-sourcemaps');
 const stylelint = require('stylelint');
 const syntaxScss = require('postcss-scss');
 
-function buildConfig(invocationArgs, sourceRoot, exportRoot) {
+function buildConfig(invocationArgs, sourceRoot, testRoot, exportRoot) {
 
   const invocationOptions = minimist(
     invocationArgs, {
@@ -31,10 +31,12 @@ function buildConfig(invocationArgs, sourceRoot, exportRoot) {
   config.environment = invocationOptions.environment;
   config.sassLinting = invocationOptions['sass-lint'] !== 'false';
   config.sourceRoot = sourceRoot;
+  config.testRoot = testRoot;
   config.exportRoot = exportRoot;
 
   config.dir = {
     src: {},
+    test: {},
     out: {}
   };
   config.dir.src.css = `${config.sourceRoot}css/`;
@@ -42,6 +44,8 @@ function buildConfig(invocationArgs, sourceRoot, exportRoot) {
   config.dir.src.images = `${config.sourceRoot}images/`;
   config.dir.src.fonts = `${config.sourceRoot}fonts/`;
   config.dir.src.templates = `${config.sourceRoot}_patterns/`;
+
+  config.dir.test.sass = `${config.testRoot}sass/`;
 
   config.dir.out.css = `${config.exportRoot}css/`;
   config.dir.out.sass = `${config.dir.out.css}sass/`;
@@ -51,6 +55,7 @@ function buildConfig(invocationArgs, sourceRoot, exportRoot) {
 
   config.files = {
     src: {},
+    test: {},
     out: {}
   };
   config.files.src.css = [
@@ -64,15 +69,18 @@ function buildConfig(invocationArgs, sourceRoot, exportRoot) {
   config.files.src.fonts = [`${config.dir.src.fonts}/*`, `${config.dir.src.fonts}/**/*`];
   config.files.src.templates = [`${config.dir.src.templates}/*.twig`, `${config.dir.src.templates}/**/*.twig`];
 
+  config.files.test.sass = `${config.dir.test.sass}**/*.spec.scss`;
+  config.files.test.sassTestsEntryPoint = `${config.dir.test.sass}test_sass.js`;
+
   config.files.out.cssFilename = invocationOptions.cssOutFilename;
 
   return config;
 
 }
 
-const config = buildConfig(process.argv, 'source/', 'export/');
+const config = buildConfig(process.argv, 'source/', 'test/', 'export/');
 
-gulp.task('css:generate', [/*'sass:test'*/], () => {
+gulp.task('css:generate', ['sass:test'], () => {
   const sassOptions = config.environment === 'production' ? {outputStyle: 'compressed'} : null;
   return gulp.src(config.files.src.sassEntryPoint)
              .pipe(sourcemaps.init())
@@ -104,7 +112,7 @@ gulp.task('sass:lint', ['css:clean'], () => {
 });
 
 gulp.task('sass:test', ['sass:lint'], () => {
-  return gulp.src('./test/sass/test_sass.js')
+  return gulp.src(config.files.test.sassTestsEntryPoint)
              .pipe(mocha({ reporter: 'spec' }));
 });
 
@@ -137,6 +145,10 @@ gulp.task('exportPatterns', ['build', 'patternsExport:clean'], () => {
       .pipe(flatten({ includeParents: false }))
       .pipe(gulp.dest(config.dir.out.templates));
 
+});
+
+gulp.task('sass:watch', () => {
+  gulp.watch([config.files.src.sass, config.files.test.sass], ['css:generate'] );
 });
 
 gulp.task('default', ['exportPatterns']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,7 +72,7 @@ function buildConfig(invocationArgs, sourceRoot, exportRoot) {
 
 const config = buildConfig(process.argv, 'source/', 'export/');
 
-gulp.task('css:generate', ['sass:test'], () => {
+gulp.task('css:generate', [/*'sass:test'*/], () => {
   const sassOptions = config.environment === 'production' ? {outputStyle: 'compressed'} : null;
   return gulp.src(config.files.src.sassEntryPoint)
              .pipe(sourcemaps.init())

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -92,7 +92,7 @@
       @if $firstValue == $secondValue {
         padding-inline: $derivedFirstValue;
       } @else {
-        &#{$libero-selector-to-force-sass-output-order} {
+        html[dir] & {
           padding-inline: $derivedFirstValue $derivedSecondValue;
         }
       }
@@ -114,7 +114,7 @@
       &[dir="rtl"] {
         padding-right: 0;
       }
-      &#{$libero-selector-to-force-sass-output-order} {
+      html[dir] & {
         padding-inline-start: 0;
       }
     } @else {
@@ -126,7 +126,7 @@
       &[dir="rtl"] {
         @include _padding-right(nth($size_in_px, 1));
       }
-      &#{$libero-selector-to-force-sass-output-order} {
+      html[dir] & {
         padding-inline-start: #{get-rem-from-px(nth($size_in_px, 1))}rem;
       }
     }
@@ -142,7 +142,7 @@
       &[dir="rtl"] {
         padding-left: 0;
       }
-      &#{$libero-selector-to-force-sass-output-order} {
+      html[dir] & {
         padding-inline-end: 0;
       }
     } @else {
@@ -154,7 +154,7 @@
       &[dir="rtl"] {
         @include _padding-left(nth($size_in_px, 1));
       }
-      &#{$libero-selector-to-force-sass-output-order} {
+      html[dir] & {
         padding-inline-end: #{get-rem-from-px(nth($size_in_px, 1))}rem;
       }
     }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -357,8 +357,8 @@
 
 @mixin h2-spacing() {
   margin: 0;
-  @include padding(21, "bottom");
-  @include padding(21, "top");
+  @include padding(21, "block-end");
+  @include padding(21, "block-start");
 }
 
 @mixin h3-spacing() {
@@ -381,8 +381,8 @@
 
 @mixin h6-spacing() {
   margin: 0;
-  @include padding(10, "top");
-  @include padding(14, "bottom");
+  @include padding(10, "block-start");
+  @include padding(14, "block-end");
 }
 
 @mixin body-spacing() {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -2,8 +2,12 @@
 @import "variables";
 
 @mixin _padding-left($size-in-px) {
-  padding-left: #{$size_in_px}px;
-  padding-left: #{get-rem-from-px($size_in_px)}rem;
+  @if $size-in-px == 0 {
+    padding-left: 0;
+  } @else {
+    padding-left: #{$size_in_px}px;
+    padding-left: #{get-rem-from-px($size_in_px)}rem;
+  }
 }
 
 @mixin _padding-right($size-in-px) {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -1,6 +1,8 @@
 @import "utility-functions";
 @import "variables";
 
+// NOTE: mixins beginning with underscore "_" are internal to this file only: they MUST NOT be used externally.
+
 @mixin _padding-left($size-in-px) {
   @if $size-in-px == 0 {
     padding-left: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -101,6 +101,12 @@
       padding-top: 0;
       padding-bottom: 0;
       padding-block: 0;
+    } @else {
+      padding-top: #{$size_in_px}px;
+      padding-top: #{get-rem-from-px($size_in_px)}rem;
+      padding-bottom: #{$size_in_px}px;
+      padding-bottom: #{get-rem-from-px($size_in_px)}rem;
+      padding-block: #{get-rem-from-px($size_in_px)}rem;
     }
   }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -1,6 +1,5 @@
 @import "utility-functions";
-@import "variables--baseline-grid";
-@import "variables--breakpoints";
+@import "variables";
 
 @mixin padding($size_in_px, $dimension: "") {
   @if $dimension == "" {
@@ -16,6 +15,26 @@
       padding-left: 0;
       padding-right: 0;
       padding-inline: 0;
+    } @else if type_of($size_in_px) == list and length($size_in_px) == 2 {
+
+      &[dir="ltr"] {
+        padding-left: #{nth($size_in_px, 1)}px;
+        padding-left: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+        padding-right: #{nth($size_in_px, 2)}px;
+        padding-right: #{get-rem-from-px(nth($size_in_px, 2))}rem;
+      }
+
+      &[dir="rtl"] {
+        padding-right: #{nth($size_in_px, 1)}px;
+        padding-right: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+        padding-left: #{nth($size_in_px, 2)}px;
+        padding-left: #{get-rem-from-px(nth($size_in_px, 2))}rem;
+      }
+
+      &#{$libero-selector-to-force-sass-output-order} {
+        padding-inline: #{get-rem-from-px(nth($size_in_px, 1))}rem #{get-rem-from-px(nth($size_in_px, 2))}rem;
+      }
+
     } @else {
       padding-left: #{$size_in_px}px;
       padding-left: #{get-rem-from-px($size_in_px)}rem;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -95,6 +95,15 @@
       }
     }
   }
+
+  @if $dimension == "block" {
+    @if $size_in_px == 0 {
+      padding-top: 0;
+      padding-bottom: 0;
+      padding-block: 0;
+    }
+  }
+
 }
 
 @mixin padding-old($size_in_px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -12,11 +12,17 @@
     }
   }
   @if $dimension == "inline" {
-    padding-left: #{$size_in_px}px;
-    padding-left: #{get-rem-from-px($size_in_px)}rem;
-    padding-right: #{$size_in_px}px;
-    padding-right: #{get-rem-from-px($size_in_px)}rem;
-    padding-inline: #{get-rem-from-px($size_in_px)}rem;
+    @if $size_in_px == 0 {
+      padding-left: 0;
+      padding-right: 0;
+      padding-inline: 0;
+    } @else {
+      padding-left: #{$size_in_px}px;
+      padding-left: #{get-rem-from-px($size_in_px)}rem;
+      padding-right: #{$size_in_px}px;
+      padding-right: #{get-rem-from-px($size_in_px)}rem;
+      padding-inline: #{get-rem-from-px($size_in_px)}rem;
+    }
   }
 }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -11,8 +11,12 @@
 }
 
 @mixin _padding-right($size-in-px) {
-  padding-right: #{$size_in_px}px;
-  padding-right: #{get-rem-from-px($size_in_px)}rem;
+  @if $size-in-px == 0 {
+    padding-right: 0;
+  } @else {
+    padding-right: #{$size_in_px}px;
+    padding-right: #{get-rem-from-px($size_in_px)}rem;
+  }
 }
 
 @mixin padding($size_in_px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -3,6 +3,14 @@
 @import "variables--breakpoints";
 
 @mixin padding($size_in_px, $dimension: "") {
+  @if $dimension == "" {
+    @if $size_in_px == 0 {
+      padding: 0;
+    }
+  }
+}
+
+@mixin padding-old($size_in_px, $dimension: "") {
   @if $dimension == top or $dimension == right or $dimension == bottom or $dimension == left {
     @if $size_in_px == 0 {
       padding-#{$dimension}: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -28,17 +28,13 @@
     } @else if type_of($size_in_px) == list and length($size_in_px) == 2 {
 
       &[dir="ltr"] {
-        padding-left: #{nth($size_in_px, 1)}px;
-        padding-left: #{get-rem-from-px(nth($size_in_px, 1))}rem;
-        padding-right: #{nth($size_in_px, 2)}px;
-        padding-right: #{get-rem-from-px(nth($size_in_px, 2))}rem;
+        @include _padding-left(nth($size_in_px, 1));
+        @include _padding-right(nth($size_in_px, 2));
       }
 
       &[dir="rtl"] {
-        padding-right: #{nth($size_in_px, 1)}px;
-        padding-right: #{get-rem-from-px(nth($size_in_px, 1))}rem;
-        padding-left: #{nth($size_in_px, 2)}px;
-        padding-left: #{get-rem-from-px(nth($size_in_px, 2))}rem;
+        @include _padding-right(nth($size_in_px, 1));
+        @include _padding-left(nth($size_in_px, 2));
       }
 
       &#{$libero-selector-to-force-sass-output-order} {
@@ -46,10 +42,8 @@
       }
 
     } @else {
-      padding-left: #{$size_in_px}px;
-      padding-left: #{get-rem-from-px($size_in_px)}rem;
-      padding-right: #{$size_in_px}px;
-      padding-right: #{get-rem-from-px($size_in_px)}rem;
+      @include _padding-left($size_in_px);
+      @include _padding-right($size_in_px);
       padding-inline: #{get-rem-from-px($size_in_px)}rem;
     }
   }
@@ -67,12 +61,10 @@
       }
     } @else {
       &[dir="ltr"] {
-        padding-left: #{$size_in_px}px;
-        padding-left: #{get-rem-from-px($size_in_px)}rem;
+        @include _padding-left($size_in_px);
       }
       &[dir="rtl"] {
-        padding-right: #{$size_in_px}px;
-        padding-right: #{get-rem-from-px($size_in_px)}rem;
+        @include _padding-right($size_in_px);
       }
       &#{$libero-selector-to-force-sass-output-order} {
         padding-inline-start: #{get-rem-from-px($size_in_px)}rem;
@@ -93,12 +85,10 @@
       }
     } @else {
       &[dir="ltr"] {
-        padding-right: #{$size_in_px}px;
-        padding-right: #{get-rem-from-px($size_in_px)}rem;
+        @include _padding-right($size_in_px);
       }
       &[dir="rtl"] {
-        padding-left: #{$size_in_px}px;
-        padding-left: #{get-rem-from-px($size_in_px)}rem;
+        @include _padding-left($size_in_px);
       }
       &#{$libero-selector-to-force-sass-output-order} {
         padding-inline-end: #{get-rem-from-px($size_in_px)}rem;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -6,6 +6,11 @@
   padding-left: #{get-rem-from-px($size_in_px)}rem;
 }
 
+@mixin _padding-right($size-in-px) {
+  padding-right: #{$size_in_px}px;
+  padding-right: #{get-rem-from-px($size_in_px)}rem;
+}
+
 @mixin padding($size_in_px, $dimension: "") {
   @if $dimension == "" {
     @if $size_in_px == 0 {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -43,6 +43,20 @@
       padding-inline: #{get-rem-from-px($size_in_px)}rem;
     }
   }
+
+  @if $dimension == "inline-start" {
+    @if $size_in_px == 0 {
+      &[dir="ltr"] {
+        padding-left: 0;
+      }
+      &[dir="rtl"] {
+        padding-right: 0;
+      }
+      &#{$libero-selector-to-force-sass-output-order} {
+        padding-inline-start: 0;
+      }
+    }
+  }
 }
 
 @mixin padding-old($size_in_px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -75,13 +75,13 @@
       }
     } @else {
       &[dir="ltr"] {
-        @include _padding-left($size_in_px);
+        @include _padding-left(nth($size_in_px, 1));
       }
       &[dir="rtl"] {
-        @include _padding-right($size_in_px);
+        @include _padding-right(nth($size_in_px, 1));
       }
       &#{$libero-selector-to-force-sass-output-order} {
-        padding-inline-start: #{get-rem-from-px($size_in_px)}rem;
+        padding-inline-start: #{get-rem-from-px(nth($size_in_px, 1))}rem;
       }
     }
   }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -21,6 +21,26 @@
   }
 }
 
+// Fallbacks for CSS logical properties contained within this mixin require the following treatment of HTML dir attributes:
+//  - document level: always specified, via the HTML element
+//  - block level: specified on every element within a block describing a direction switch.
+//
+// For example:
+// <html lang="..." dir="ltr">
+// ...
+// <div>
+//   Doesn't need a dir attribute. Most cases will be like this.
+// </div>
+//
+//<div class="test" dir="rtl">
+//
+//  This block changes the text direction. Every descendant element must have its own dir attribute....
+//
+//  <div class="test" dir="rtl">... even if the direction doesn't change.</div>
+//
+//  <div class="test" dir="ltr">But obviously also when it does.</div>
+//
+//</div>
 @mixin padding($size_in_px, $dimension: "") {
   @if $dimension == "" {
     @if $size_in_px == 0 {
@@ -47,11 +67,13 @@
 
       } @else {
 
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
           @include _padding-left($firstValue);
           @include _padding-right($secondValue);
         }
 
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
           @include _padding-right($firstValue);
           @include _padding-left($secondValue);
@@ -84,9 +106,11 @@
 
   @if $dimension == "inline-start" {
     @if $size_in_px == 0 {
+      html[dir="ltr"] &:not([dir]),
       &[dir="ltr"] {
         padding-left: 0;
       }
+      html[dir="rtl"] &:not([dir]),
       &[dir="rtl"] {
         padding-right: 0;
       }
@@ -94,9 +118,11 @@
         padding-inline-start: 0;
       }
     } @else {
+      html[dir="ltr"] &:not([dir]),
       &[dir="ltr"] {
         @include _padding-left(nth($size_in_px, 1));
       }
+      html[dir="rtl"] &:not([dir]),
       &[dir="rtl"] {
         @include _padding-right(nth($size_in_px, 1));
       }
@@ -108,9 +134,11 @@
 
   @if $dimension == "inline-end" {
     @if $size_in_px == 0 {
+      html[dir="ltr"] &:not([dir]),
       &[dir="ltr"] {
         padding-right: 0;
       }
+      html[dir="rtl"] &:not([dir]),
       &[dir="rtl"] {
         padding-left: 0;
       }
@@ -118,9 +146,11 @@
         padding-inline-end: 0;
       }
     } @else {
+      html[dir="ltr"] &:not([dir]),
       &[dir="ltr"] {
         @include _padding-right(nth($size_in_px, 1));
       }
+      html[dir="rtl"] &:not([dir]),
       &[dir="rtl"] {
         @include _padding-left(nth($size_in_px, 1));
       }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -1,6 +1,11 @@
 @import "utility-functions";
 @import "variables";
 
+@mixin _padding-left($size-in-px) {
+  padding-left: #{$size_in_px}px;
+  padding-left: #{get-rem-from-px($size_in_px)}rem;
+}
+
 @mixin padding($size_in_px, $dimension: "") {
   @if $dimension == "" {
     @if $size_in_px == 0 {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -33,7 +33,7 @@
       padding-left: 0;
       padding-right: 0;
       padding-inline: 0;
-    } @else if type_of($size_in_px) == list and length($size_in_px) == 2 {
+    } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
 
       $firstValue: nth($size_in_px, 1);
       $secondValue: nth($size_in_px, 2);

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -69,6 +69,20 @@
       }
     }
   }
+
+  @if $dimension == "inline-end" {
+    @if $size_in_px == 0 {
+      &[dir="ltr"] {
+        padding-right: 0;
+      }
+      &[dir="rtl"] {
+        padding-left: 0;
+      }
+      &#{$libero-selector-to-force-sass-output-order} {
+        padding-inline-end: 0;
+      }
+    }
+  }
 }
 
 @mixin padding-old($size_in_px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -70,7 +70,7 @@
           padding-inline: $derivedFirstValue $derivedSecondValue;
         }
       } @else {
-        padding-inline: $derivedFirstValue $derivedSecondValue;
+        padding-inline: $derivedFirstValue;
       }
 
     } @else {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -6,6 +6,9 @@
   @if $dimension == "" {
     @if $size_in_px == 0 {
       padding: 0;
+    } @else {
+      padding: #{$size_in_px}px;
+      padding: #{get-rem-from-px($size_in_px)}rem;
     }
   }
 }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -135,7 +135,7 @@
       padding-bottom: 0;
       padding-block: 0;
 
-    } @else if type_of($size_in_px) == list and length($size_in_px) == 2 {
+    } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
       padding-top: #{nth($size_in_px, 1)}px;
       padding-top: #{get-rem-from-px(nth($size_in_px, 1))}rem;
       padding-bottom: #{nth($size_in_px, 2)}px;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -1,24 +1,6 @@
 @import "utility-functions";
 @import "variables";
 
-@mixin _padding-left($size-in-px) {
-  @if $size-in-px == 0 {
-    padding-left: 0;
-  } @else {
-    padding-left: #{$size_in_px}px;
-    padding-left: #{get-rem-from-px($size_in_px)}rem;
-  }
-}
-
-@mixin _padding-right($size-in-px) {
-  @if $size-in-px == 0 {
-    padding-right: 0;
-  } @else {
-    padding-right: #{$size_in_px}px;
-    padding-right: #{get-rem-from-px($size_in_px)}rem;
-  }
-}
-
 @mixin padding($size_in_px, $dimension: "") {
   @if $dimension == "" {
     @if $size_in_px == 0 {
@@ -151,6 +133,24 @@
     }
   }
 
+}
+
+@mixin _padding-left($size-in-px) {
+  @if $size-in-px == 0 {
+    padding-left: 0;
+  } @else {
+    padding-left: #{$size_in_px}px;
+    padding-left: #{get-rem-from-px($size_in_px)}rem;
+  }
+}
+
+@mixin _padding-right($size-in-px) {
+  @if $size-in-px == 0 {
+    padding-right: 0;
+  } @else {
+    padding-right: #{$size_in_px}px;
+    padding-right: #{get-rem-from-px($size_in_px)}rem;
+  }
 }
 
 @mixin margin($size_in_px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -96,11 +96,20 @@
     }
   }
 
+  // Vertical writing modes not yet supported
   @if $dimension == "block" {
     @if $size_in_px == 0 {
       padding-top: 0;
       padding-bottom: 0;
       padding-block: 0;
+
+    } @else if type_of($size_in_px) == list and length($size_in_px) == 2 {
+      padding-top: #{nth($size_in_px, 1)}px;
+      padding-top: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+      padding-bottom: #{nth($size_in_px, 2)}px;
+      padding-bottom: #{get-rem-from-px(nth($size_in_px, 2))}rem;
+      padding-block: #{get-rem-from-px(nth($size_in_px, 1))}rem #{get-rem-from-px(nth($size_in_px, 2))}rem;;
+
     } @else {
       padding-top: #{$size_in_px}px;
       padding-top: #{get-rem-from-px($size_in_px)}rem;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -65,12 +65,12 @@
       @if $secondValue != 0 {
         $derivedSecondValue: #{get-rem-from-px($secondValue)}rem;
       }
-      @if $firstValue != $secondValue {
+      @if $firstValue == $secondValue {
+        padding-inline: $derivedFirstValue;
+      } @else {
         &#{$libero-selector-to-force-sass-output-order} {
           padding-inline: $derivedFirstValue $derivedSecondValue;
         }
-      } @else {
-        padding-inline: $derivedFirstValue;
       }
 
     } @else {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -81,6 +81,18 @@
       &#{$libero-selector-to-force-sass-output-order} {
         padding-inline-end: 0;
       }
+    } @else {
+      &[dir="ltr"] {
+        padding-right: #{$size_in_px}px;
+        padding-right: #{get-rem-from-px($size_in_px)}rem;
+      }
+      &[dir="rtl"] {
+        padding-left: #{$size_in_px}px;
+        padding-left: #{get-rem-from-px($size_in_px)}rem;
+      }
+      &#{$libero-selector-to-force-sass-output-order} {
+        padding-inline-end: #{get-rem-from-px($size_in_px)}rem;
+      }
     }
   }
 }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -99,13 +99,13 @@
       }
     } @else {
       &[dir="ltr"] {
-        @include _padding-right($size_in_px);
+        @include _padding-right(nth($size_in_px, 1));
       }
       &[dir="rtl"] {
-        @include _padding-left($size_in_px);
+        @include _padding-left(nth($size_in_px, 1));
       }
       &#{$libero-selector-to-force-sass-output-order} {
-        padding-inline-end: #{get-rem-from-px($size_in_px)}rem;
+        padding-inline-end: #{get-rem-from-px(nth($size_in_px, 1))}rem;
       }
     }
   }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -55,6 +55,18 @@
       &#{$libero-selector-to-force-sass-output-order} {
         padding-inline-start: 0;
       }
+    } @else {
+      &[dir="ltr"] {
+        padding-left: #{$size_in_px}px;
+        padding-left: #{get-rem-from-px($size_in_px)}rem;
+      }
+      &[dir="rtl"] {
+        padding-right: #{$size_in_px}px;
+        padding-right: #{get-rem-from-px($size_in_px)}rem;
+      }
+      &#{$libero-selector-to-force-sass-output-order} {
+        padding-inline-start: #{get-rem-from-px($size_in_px)}rem;
+      }
     }
   }
 }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -21,6 +21,20 @@
   }
 }
 
+@mixin _when-left-to-right {
+  html[dir="ltr"] &:not([dir]),
+  &[dir="ltr"] {
+    @content;
+  }
+}
+
+@mixin _when-right-to-left {
+  html[dir="rtl"] &:not([dir]),
+  &[dir="rtl"] {
+    @content;
+  }
+}
+
 // Fallbacks for CSS logical properties contained within this mixin require the following treatment of HTML dir attributes:
 //  - document level: always specified, via the HTML element
 //  - block level: specified on every element within a block describing a direction switch.
@@ -67,14 +81,12 @@
 
       } @else {
 
-        html[dir="ltr"] &:not([dir]),
-        &[dir="ltr"] {
+        @include _when-left-to-right {
           @include _padding-left($firstValue);
           @include _padding-right($secondValue);
         }
 
-        html[dir="rtl"] &:not([dir]),
-        &[dir="rtl"] {
+        @include _when-right-to-left {
           @include _padding-right($firstValue);
           @include _padding-left($secondValue);
         }
@@ -106,24 +118,20 @@
 
   @if $dimension == "inline-start" {
     @if $size_in_px == 0 {
-      html[dir="ltr"] &:not([dir]),
-      &[dir="ltr"] {
+      @include _when-left-to-right {
         padding-left: 0;
       }
-      html[dir="rtl"] &:not([dir]),
-      &[dir="rtl"] {
+      @include _when-right-to-left {
         padding-right: 0;
       }
       html[dir] & {
         padding-inline-start: 0;
       }
     } @else {
-      html[dir="ltr"] &:not([dir]),
-      &[dir="ltr"] {
+      @include _when-left-to-right {
         @include _padding-left(nth($size_in_px, 1));
       }
-      html[dir="rtl"] &:not([dir]),
-      &[dir="rtl"] {
+      @include _when-right-to-left {
         @include _padding-right(nth($size_in_px, 1));
       }
       html[dir] & {
@@ -134,24 +142,20 @@
 
   @if $dimension == "inline-end" {
     @if $size_in_px == 0 {
-      html[dir="ltr"] &:not([dir]),
-      &[dir="ltr"] {
+      @include _when-left-to-right {
         padding-right: 0;
       }
-      html[dir="rtl"] &:not([dir]),
-      &[dir="rtl"] {
+      @include _when-right-to-left {
         padding-left: 0;
       }
       html[dir] & {
         padding-inline-end: 0;
       }
     } @else {
-      html[dir="ltr"] &:not([dir]),
-      &[dir="ltr"] {
+      @include _when-left-to-right {
         @include _padding-right(nth($size_in_px, 1));
       }
-      html[dir="rtl"] &:not([dir]),
-      &[dir="rtl"] {
+      @include _when-right-to-left {
         @include _padding-left(nth($size_in_px, 1));
       }
       html[dir] & {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -153,45 +153,6 @@
 
 }
 
-@mixin padding-old($size_in_px, $dimension: "") {
-  @if $dimension == top or $dimension == right or $dimension == bottom or $dimension == left {
-    @if $size_in_px == 0 {
-      padding-#{$dimension}: 0;
-    } @else {
-      padding-#{$dimension}: #{$size_in_px}px;
-      padding-#{$dimension}: #{get-rem-from-px($size_in_px)}rem;
-    }
-  }
-  @else if $dimension == "" and type_of($size_in_px) == list {
-    $parts-px: ();
-    $parts-rem: ();
-    @each $size in $size_in_px {
-      @if $size == 0 {
-        $parts-px: append($parts-px, 0, "space");
-      } @else {
-        $parts-px: append($parts-px, #{$size}px, "space");
-      }
-    }
-    @each $size in $size_in_px {
-      @if $size == 0 {
-        $parts-rem: append($parts-rem, 0, "space");
-      } @else {
-        $parts-rem: append($parts-rem, #{get-rem-from-px($size)}rem, "space");
-      }
-    }
-    padding: $parts-px;
-    padding: $parts-rem;
-  }
-  @else {
-    @if $size_in_px == 0 {
-      padding: 0;
-    } @else {
-      padding: #{$size_in_px}px;
-      padding: #{get-rem-from-px($size_in_px)}rem;
-    }
-  }
-}
-
 @mixin margin($size_in_px, $dimension: "") {
   @if $dimension == top or $dimension == right or $dimension == bottom or $dimension == left {
     @if $size_in_px == 0 {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -35,18 +35,42 @@
       padding-inline: 0;
     } @else if type_of($size_in_px) == list and length($size_in_px) == 2 {
 
-      &[dir="ltr"] {
-        @include _padding-left(nth($size_in_px, 1));
-        @include _padding-right(nth($size_in_px, 2));
+      $firstValue: nth($size_in_px, 1);
+      $secondValue: nth($size_in_px, 2);
+
+      @if $firstValue == $secondValue {
+
+        @include _padding-left($firstValue);
+        @include _padding-right($secondValue);
+
+      } @else {
+
+        &[dir="ltr"] {
+          @include _padding-left($firstValue);
+          @include _padding-right($secondValue);
+        }
+
+        &[dir="rtl"] {
+          @include _padding-right($firstValue);
+          @include _padding-left($secondValue);
+        }
+
       }
 
-      &[dir="rtl"] {
-        @include _padding-right(nth($size_in_px, 1));
-        @include _padding-left(nth($size_in_px, 2));
+      $derivedFirstValue: 0;
+      $derivedSecondValue: 0;
+      @if $firstValue != 0 {
+        $derivedFirstValue: #{get-rem-from-px($firstValue)}rem;
       }
-
-      &#{$libero-selector-to-force-sass-output-order} {
-        padding-inline: #{get-rem-from-px(nth($size_in_px, 1))}rem #{get-rem-from-px(nth($size_in_px, 2))}rem;
+      @if $secondValue != 0 {
+        $derivedSecondValue: #{get-rem-from-px($secondValue)}rem;
+      }
+      @if $firstValue != $secondValue {
+        &#{$libero-selector-to-force-sass-output-order} {
+          padding-inline: $derivedFirstValue $derivedSecondValue;
+        }
+      } @else {
+        padding-inline: $derivedFirstValue $derivedSecondValue;
       }
 
     } @else {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -1,6 +1,24 @@
 @import "utility-functions";
 @import "variables";
 
+@mixin _padding-left($size-in-px) {
+  @if $size-in-px == 0 {
+    padding-left: 0;
+  } @else {
+    padding-left: #{$size_in_px}px;
+    padding-left: #{get-rem-from-px($size_in_px)}rem;
+  }
+}
+
+@mixin _padding-right($size-in-px) {
+  @if $size-in-px == 0 {
+    padding-right: 0;
+  } @else {
+    padding-right: #{$size_in_px}px;
+    padding-right: #{get-rem-from-px($size_in_px)}rem;
+  }
+}
+
 @mixin padding($size_in_px, $dimension: "") {
   @if $dimension == "" {
     @if $size_in_px == 0 {
@@ -133,24 +151,6 @@
     }
   }
 
-}
-
-@mixin _padding-left($size-in-px) {
-  @if $size-in-px == 0 {
-    padding-left: 0;
-  } @else {
-    padding-left: #{$size_in_px}px;
-    padding-left: #{get-rem-from-px($size_in_px)}rem;
-  }
-}
-
-@mixin _padding-right($size-in-px) {
-  @if $size-in-px == 0 {
-    padding-right: 0;
-  } @else {
-    padding-right: #{$size_in_px}px;
-    padding-right: #{get-rem-from-px($size_in_px)}rem;
-  }
 }
 
 @mixin margin($size_in_px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -11,6 +11,13 @@
       padding: #{get-rem-from-px($size_in_px)}rem;
     }
   }
+  @if $dimension == "inline" {
+    padding-left: #{$size_in_px}px;
+    padding-left: #{get-rem-from-px($size_in_px)}rem;
+    padding-right: #{$size_in_px}px;
+    padding-right: #{get-rem-from-px($size_in_px)}rem;
+    padding-inline: #{get-rem-from-px($size_in_px)}rem;
+  }
 }
 
 @mixin padding-old($size_in_px, $dimension: "") {

--- a/source/css/sass/_normalize-overrides.scss
+++ b/source/css/sass/_normalize-overrides.scss
@@ -136,7 +136,7 @@ ul,
 ol {
   @include blg-spacing("bottom", "small", "margin");
   margin-top: 0;
-  @include padding(48, "left");
+  @include padding(48, "inline-start");
 }
 
 dl {

--- a/source/css/sass/_variables.scss
+++ b/source/css/sass/_variables.scss
@@ -10,6 +10,6 @@ $libero-box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.5);
  providing fallback for (e.g. when using the dir attribute selector to fallback from padding-inline in the padding mixin).
  Sass will put these higher specificity selectors after the code they are providing fallbacks for, which is not what we
  want. Introducing this selector on the non-fallback increases the specificity of the authored code so it occurs after
- the fallbacks. The minor increase in specificity in unavoidable, but this seems an acceptable trade off.
+ the fallbacks. The minor increase in specificity is unavoidable, but this seems an acceptable trade off.
 */
 $libero-selector-to-force-sass-output-order: ":not([data-never-use-this-data-attribute-name-in-html])";

--- a/source/css/sass/_variables.scss
+++ b/source/css/sass/_variables.scss
@@ -4,3 +4,12 @@
 @import "variables--breakpoints";
 
 $libero-box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.5);
+
+/*
+ This is needed to force selector order in some situations where a fallback has higher specificity than the code it's
+ providing fallback for (e.g. when using the dir attribute selector to fallback from padding-inline in the padding mixin).
+ Sass will put these higher specificity selectors after the code they are providing fallbacks for, which is not what we
+ want. Introducing this selector on the non-fallback increases the specificity of the authored code so it occurs after
+ the fallbacks. The minor increase in specificity in unavoidable, but this seems an acceptable trade off.
+*/
+$libero-selector-to-force-sass-output-order: ":not([data-never-use-this-data-attribute-name-in-html])";

--- a/source/css/sass/_variables.scss
+++ b/source/css/sass/_variables.scss
@@ -4,12 +4,3 @@
 @import "variables--breakpoints";
 
 $libero-box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.5);
-
-/*
- This is needed to force selector order in some situations where a fallback has higher specificity than the code it's
- providing fallback for (e.g. when using the dir attribute selector to fallback from padding-inline in the padding mixin).
- Sass will put these higher specificity selectors after the code they are providing fallbacks for, which is not what we
- want. Introducing this selector on the non-fallback increases the specificity of the authored code so it occurs after
- the fallbacks. The minor increase in specificity is unavoidable, but this seems an acceptable trade off.
-*/
-$libero-selector-to-force-sass-output-order: ":not([data-never-use-this-data-attribute-name-in-html])";

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -74,12 +74,14 @@
       }
 
       @include expect {
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
           padding-left: 16px;
           padding-left: 1rem;
           padding-right: 32px;
           padding-right: 2rem;
         }
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
           padding-right: 16px;
           padding-right: 1rem;
@@ -117,11 +119,13 @@
       }
 
       @include expect {
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
           padding-left: 0;
           padding-right: 32px;
           padding-right: 2rem;
         }
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
           padding-right: 0;
           padding-left: 32px;
@@ -142,11 +146,13 @@
       }
 
       @include expect {
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
           padding-left: 16px;
           padding-left: 1rem;
           padding-right: 0;
         }
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
           padding-right: 16px;
           padding-right: 1rem;
@@ -183,12 +189,14 @@
         }
 
         @include expect {
+          html[dir="ltr"] &:not([dir]),
           &[dir="ltr"] {
             padding-left: 16px;
             padding-left: 1rem;
             padding-right: 32px;
             padding-right: 2rem;
           }
+          html[dir="rtl"] &:not([dir]),
           &[dir="rtl"] {
             padding-right: 16px;
             padding-right: 1rem;
@@ -211,9 +219,11 @@
      }
 
      @include expect {
+       html[dir="ltr"] &:not([dir]),
        &[dir="ltr"] {
          padding-left: 0;
        }
+       html[dir="rtl"] &:not([dir]),
        &[dir="rtl"] {
          padding-right: 0;
        }
@@ -233,10 +243,12 @@
      }
 
      @include expect {
+       html[dir="ltr"] &:not([dir]),
        &[dir="ltr"] {
          padding-left: 16px;
          padding-left: 1rem;
        }
+       html[dir="rtl"] &:not([dir]),
        &[dir="rtl"] {
          padding-right: 16px;
          padding-right: 1rem;
@@ -256,10 +268,12 @@
       }
 
       @include expect {
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
           padding-left: 16px;
           padding-left: 1rem;
         }
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
           padding-right: 16px;
           padding-right: 1rem;
@@ -280,9 +294,11 @@
       }
 
       @include expect {
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
          padding-right: 0;
         }
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
          padding-left: 0;
         }
@@ -302,10 +318,12 @@
      }
 
      @include expect {
+       html[dir="ltr"] &:not([dir]),
        &[dir="ltr"] {
          padding-right: 16px;
          padding-right: 1rem;
        }
+       html[dir="rtl"] &:not([dir]),
        &[dir="rtl"] {
          padding-left: 16px;
          padding-left: 1rem;
@@ -326,10 +344,12 @@
       }
 
       @include expect {
+        html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
           padding-right: 16px;
           padding-right: 1rem;
         }
+        html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
           padding-left: 16px;
           padding-left: 1rem;

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -1,6 +1,23 @@
 @import "../../node_modules/sass-true/sass/true";
 @import "../../source/css/sass/_mixins--spacing.scss";
 
+@include describe('_padding-left [Mixin]') {
+  @include it('generates expected padding-left declaration with appropriate fallbacks') {
+    @include assert() {
+
+      @include output {
+        @include _padding-left(16);
+      }
+
+      @include expect {
+        padding-left: 16px;
+        padding-left: 1rem;
+      }
+
+    }
+  }
+}
+
 @include describe("padding [Mixin]") {
 
   @include it("generates correct fallbacks with a single zero value and no dimension") {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -219,6 +219,22 @@
    }
 }
 
+  @include it("generates correct fallbacks with a single zero value for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include padding(0, "block")
+      }
+
+      @include expect {
+        padding-top: 0;
+        padding-bottom: 0;
+        padding-block: 0;
+      }
+
+    }
+  }
+
   //@include it("generates correct fallbacks with a single value for dimension 'block'") {
   //  @include assert() {
   //

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -32,23 +32,23 @@
     }
   }
 
-  //@include it("generates correct fallbacks with a single value for dimension 'inline'") {
-  //  @include assert() {
-  //
-  //    @include output {
-  //      @include padding(16, "inline");
-  //    }
-  //
-  //    @include expect {
-  //      padding-left: 16px;
-  //      padding-left: 1rem;
-  //      padding-right: 16px;
-  //      padding-right: 1rem;
-  //      padding-inline: 1rem;
-  //    }
-  //
-  //  }
-  //}
+  @include it("generates correct fallbacks with a single non-zero value for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "inline");
+      }
+
+      @include expect {
+        padding-left: 16px;
+        padding-left: 1rem;
+        padding-right: 16px;
+        padding-right: 1rem;
+        padding-inline: 1rem;
+      }
+
+    }
+  }
 
   //@include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
   //  @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -32,6 +32,22 @@
     }
   }
 
+  @include it("generates correct fallbacks with a single zero value for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include padding(0, "inline");
+      }
+
+      @include expect {
+        padding-left: 0;
+        padding-right: 0;
+        padding-inline: 0;
+      }
+
+    }
+  }
+
   @include it("generates correct fallbacks with a single non-zero value for dimension 'inline'") {
     @include assert() {
 

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -94,14 +94,36 @@
 
     }
   }
-  //
-  //@include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
+  
+  @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
+   @include assert() {
+  
+     @include output {
+       @include padding(0, "inline-start");
+     }
+  
+     @include expect {
+       &[dir="ltr"] {
+         padding-left: 0;
+       }
+       &[dir="rtl"] {
+         padding-right: 0;
+       }
+       &:not([data-never-use-this-data-attribute-name-in-html]) {
+        padding-inline-start: 0;
+       }
+  
+   }
+  }
+}
+
+  // @include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
   //  @include assert() {
-  //
+  
   //    @include output {
   //      @include padding(16, "inline-start");
   //    }
-  //
+  
   //    @include expect {
   //      &[dir="ltr"] {
   //        padding-left: 16px;
@@ -111,12 +133,13 @@
   //        padding-right: 16px;
   //        padding-right: 1rem;
   //      }
-  //      padding-inline-start: 1rem;
-  //    }
-  //
+  //      &:not([data-never-use-this-data-attribute-name-in-html]) {
+  //       padding-inline-start: 1rem;
+  //      }
+  
   //  }
-  //}
-  //
+  // }
+  
   //@include it("generates correct fallbacks with a single value for the dimension 'inline-end'") {
   //  @include assert() {
   //

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -1,0 +1,146 @@
+@import "../../node_modules/sass-true/sass/true";
+@import "../../source/css/sass/_mixins--spacing.scss";
+
+@include describe("padding [Mixin]") {
+
+  @include it("generates correct fallbacks with a single value and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(16);
+      }
+
+      @include expect {
+        padding: 16px;
+        padding: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single value for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "inline");
+      }
+
+      @include expect {
+        padding-left: 16px;
+        padding-left: 1rem;
+        padding-right: 16px;
+        padding-right: 1rem;
+        padding-inline: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32, "inline");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+          padding-right: 32px;
+          padding-right: 2rem;
+        }
+        &[dir="rtl"] {
+          padding-left: 32px;
+          padding-left: 2rem;
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        padding-inline: 1rem 2rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "inline-start");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+        }
+        &[dir="rtl"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        padding-inline-start: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single value for the dimension 'inline-end'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "inline-end");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        &[dir="rtl"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+        }
+        padding-inline-end: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single value for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "block")
+      }
+
+      @include expect {
+        padding-top: 16px;
+        padding-top: 1rem;
+        padding-bottom: 16px;
+        padding-bottom: 1rem;
+        padding-block: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a pair of values for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32, "block")
+      }
+
+      @include expect {
+        padding-top: 16px;
+        padding-top: 1rem;
+        padding-bottom: 32px;
+        padding-bottom: 2rem;
+
+        padding-block: 1rem 2rem;
+      }
+
+    }
+  }
+
+}

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -317,6 +317,31 @@
    }
 }
 
+
+  @include it("Ignores more than one value in the sizes list for the dimension 'inline-end'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32, "inline-end");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        &[dir="rtl"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+        }
+        &:not([data-never-use-this-data-attribute-name-in-html]) {
+          padding-inline-end: 1rem;
+        }
+      }
+
+    }
+  }
+
   @include it("generates correct fallbacks with a single zero value for dimension 'block'") {
     @include assert() {
 

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -66,7 +66,7 @@
     }
   }
 
-  //@include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
+  //@include it("generates correct fallbacks with a pair of different values for dimension 'inline'") {
   //  @include assert() {
   //
   //    @include output {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -94,14 +94,14 @@
 
     }
   }
-  
+
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
    @include assert() {
-  
+
      @include output {
        @include padding(0, "inline-start");
      }
-  
+
      @include expect {
        &[dir="ltr"] {
          padding-left: 0;
@@ -112,34 +112,34 @@
        &:not([data-never-use-this-data-attribute-name-in-html]) {
         padding-inline-start: 0;
        }
-  
+
    }
   }
 }
 
-  // @include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
-  //  @include assert() {
-  
-  //    @include output {
-  //      @include padding(16, "inline-start");
-  //    }
-  
-  //    @include expect {
-  //      &[dir="ltr"] {
-  //        padding-left: 16px;
-  //        padding-left: 1rem;
-  //      }
-  //      &[dir="rtl"] {
-  //        padding-right: 16px;
-  //        padding-right: 1rem;
-  //      }
-  //      &:not([data-never-use-this-data-attribute-name-in-html]) {
-  //       padding-inline-start: 1rem;
-  //      }
-  
-  //  }
-  // }
-  
+  @include it("generates correct fallbacks with a single non-zero value for the dimension 'inline-start'") {
+   @include assert() {
+
+     @include output {
+       @include padding(16, "inline-start");
+     }
+
+     @include expect {
+       &[dir="ltr"] {
+         padding-left: 16px;
+         padding-left: 1rem;
+       }
+       &[dir="rtl"] {
+         padding-right: 16px;
+         padding-right: 1rem;
+       }
+       &:not([data-never-use-this-data-attribute-name-in-html]) {
+        padding-inline-start: 1rem;
+       }
+     }
+  }
+}
+
   //@include it("generates correct fallbacks with a single value for the dimension 'inline-end'") {
   //  @include assert() {
   //

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -253,23 +253,24 @@
     }
   }
 
-  //@include it("generates correct fallbacks with a pair of values for dimension 'block'") {
-  //  @include assert() {
-  //
-  //    @include output {
-  //      @include padding(16 32, "block")
-  //    }
-  //
-  //    @include expect {
-  //      padding-top: 16px;
-  //      padding-top: 1rem;
-  //      padding-bottom: 32px;
-  //      padding-bottom: 2rem;
-  //
-  //      padding-block: 1rem 2rem;
-  //    }
-  //
-  //  }
-  //}
+  // Vertical writing modes not yet supported
+  @include it("generates correct fallbacks with a pair of non-zero values for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32, "block")
+      }
+
+      @include expect {
+        padding-top: 16px;
+        padding-top: 1rem;
+        padding-bottom: 32px;
+        padding-bottom: 2rem;
+
+        padding-block: 1rem 2rem;
+      }
+
+    }
+  }
 
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -140,28 +140,28 @@
   }
 }
 
-  //@include it("generates correct fallbacks with a single value for the dimension 'inline-end'") {
-  //  @include assert() {
-  //
-  //    @include output {
-  //      @include padding(16, "inline-end");
-  //    }
-  //
-  //    @include expect {
-  //      &[dir="ltr"] {
-  //        padding-right: 16px;
-  //        padding-right: 1rem;
-  //      }
-  //      &[dir="rtl"] {
-  //        padding-left: 16px;
-  //        padding-left: 1rem;
-  //      }
-  //      padding-inline-end: 1rem;
-  //    }
-  //
-  //  }
-  //}
-  //
+  @include it("generates correct fallbacks with a single zero value for the dimension 'inline-end'") {
+    @include assert() {
+
+      @include output {
+       @include padding(0, "inline-end");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+         padding-right: 0;
+        }
+        &[dir="rtl"] {
+         padding-left: 0;
+        }
+        &:not([data-never-use-this-data-attribute-name-in-html]) {
+          padding-inline-end: 0;
+        }
+
+      }
+    }
+  }
+
   //@include it("generates correct fallbacks with a single value for dimension 'block'") {
   //  @include assert() {
   //

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -235,7 +235,33 @@
     }
   }
 
-  // TODO: what happens when passed "inline" but a list of > 2 values?
+  @include it("Ignores more than two values in the sizes list for the dimension 'inline'") {
+      @include assert() {
+
+        @include output {
+          @include padding(16 32 48, "inline");
+        }
+
+        @include expect {
+          &[dir="ltr"] {
+            padding-left: 16px;
+            padding-left: 1rem;
+            padding-right: 32px;
+            padding-right: 2rem;
+          }
+          &[dir="rtl"] {
+            padding-right: 16px;
+            padding-right: 1rem;
+            padding-left: 32px;
+            padding-left: 2rem;
+          }
+
+          &:not([data-never-use-this-data-attribute-name-in-html]) {
+            padding-inline: 1rem 2rem;
+          }
+        }
+      }
+    }
 
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
    @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -165,9 +165,7 @@
         padding-left: 1rem;
         padding-right: 16px;
         padding-right: 1rem;
-
-        // TODO: "padding-inline: 1rem;" is better here:
-        padding-inline: 1rem 1rem;
+        padding-inline: 1rem;
       }
 
     }
@@ -231,8 +229,7 @@
       @include expect {
         padding-left: 0;
         padding-right: 0;
-        // TODO: "padding-inline: 0 0;" is better here:
-        padding-inline: 0 0;
+        padding-inline: 0;
         }
 
     }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -89,7 +89,7 @@
           padding-left: 2rem;
         }
 
-        &:not([data-never-use-this-data-attribute-name-in-html]) {
+        html[dir] & {
           padding-inline: 1rem 2rem;
         }
       }
@@ -132,7 +132,7 @@
           padding-left: 2rem;
         }
 
-        &:not([data-never-use-this-data-attribute-name-in-html]) {
+        html[dir] & {
           padding-inline: 0 2rem;
         }
       }
@@ -159,7 +159,7 @@
           padding-left: 0;
         }
 
-        &:not([data-never-use-this-data-attribute-name-in-html]) {
+        html[dir] & {
           padding-inline: 1rem 0;
         }
       }
@@ -204,7 +204,7 @@
             padding-left: 2rem;
           }
 
-          &:not([data-never-use-this-data-attribute-name-in-html]) {
+          html[dir] & {
             padding-inline: 1rem 2rem;
           }
         }
@@ -227,7 +227,7 @@
        &[dir="rtl"] {
          padding-right: 0;
        }
-       &:not([data-never-use-this-data-attribute-name-in-html]) {
+       html[dir] & {
         padding-inline-start: 0;
        }
 
@@ -253,7 +253,7 @@
          padding-right: 16px;
          padding-right: 1rem;
        }
-       &:not([data-never-use-this-data-attribute-name-in-html]) {
+       html[dir] & {
         padding-inline-start: 1rem;
        }
      }
@@ -278,7 +278,7 @@
           padding-right: 16px;
           padding-right: 1rem;
         }
-        &:not([data-never-use-this-data-attribute-name-in-html]) {
+        html[dir] & {
           padding-inline-start: 1rem;
         }
       }
@@ -302,7 +302,7 @@
         &[dir="rtl"] {
          padding-left: 0;
         }
-        &:not([data-never-use-this-data-attribute-name-in-html]) {
+        html[dir] & {
           padding-inline-end: 0;
         }
 
@@ -328,7 +328,7 @@
          padding-left: 16px;
          padding-left: 1rem;
        }
-       &:not([data-never-use-this-data-attribute-name-in-html]) {
+       html[dir] & {
         padding-inline-end: 1rem;
        }
      }
@@ -354,7 +354,7 @@
           padding-left: 16px;
           padding-left: 1rem;
         }
-        &:not([data-never-use-this-data-attribute-name-in-html]) {
+        html[dir] & {
           padding-inline-end: 1rem;
         }
       }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -45,6 +45,19 @@
       }
 
     }
+
+    @include assert() {
+
+      @include output {
+        @include _padding-right(0);
+      }
+
+      @include expect {
+        padding-right: 0;
+      }
+
+    }
+
   }
 }
 

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -17,20 +17,20 @@
     }
   }
 
-  //@include it("generates correct fallbacks with a single non-zero value and no dimension") {
-  //  @include assert() {
-  //
-  //    @include output {
-  //      @include padding(16);
-  //    }
-  //
-  //    @include expect {
-  //      padding: 16px;
-  //      padding: 1rem;
-  //    }
-  //
-  //  }
-  //}
+  @include it("generates correct fallbacks with a single non-zero value and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(16);
+      }
+
+      @include expect {
+        padding: 16px;
+        padding: 1rem;
+      }
+
+    }
+  }
 
   //@include it("generates correct fallbacks with a single value for dimension 'inline'") {
   //  @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -66,31 +66,34 @@
     }
   }
 
-  //@include it("generates correct fallbacks with a pair of different values for dimension 'inline'") {
-  //  @include assert() {
-  //
-  //    @include output {
-  //      @include padding(16 32, "inline");
-  //    }
-  //
-  //    @include expect {
-  //      &[dir="ltr"] {
-  //        padding-left: 16px;
-  //        padding-left: 1rem;
-  //        padding-right: 32px;
-  //        padding-right: 2rem;
-  //      }
-  //      &[dir="rtl"] {
-  //        padding-left: 32px;
-  //        padding-left: 2rem;
-  //        padding-right: 16px;
-  //        padding-right: 1rem;
-  //      }
-  //      padding-inline: 1rem 2rem;
-  //    }
-  //
-  //  }
-  //}
+  @include it("generates correct fallbacks with a pair of different values for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32, "inline");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+          padding-right: 32px;
+          padding-right: 2rem;
+        }
+        &[dir="rtl"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+          padding-left: 32px;
+          padding-left: 2rem;
+        }
+
+        &:not([data-never-use-this-data-attribute-name-in-html]) {
+          padding-inline: 1rem 2rem;
+        }
+      }
+
+    }
+  }
   //
   //@include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
   //  @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -235,24 +235,24 @@
     }
   }
 
-  //@include it("generates correct fallbacks with a single value for dimension 'block'") {
-  //  @include assert() {
-  //
-  //    @include output {
-  //      @include padding(16, "block")
-  //    }
-  //
-  //    @include expect {
-  //      padding-top: 16px;
-  //      padding-top: 1rem;
-  //      padding-bottom: 16px;
-  //      padding-bottom: 1rem;
-  //      padding-block: 1rem;
-  //    }
-  //
-  //  }
-  //}
-  //
+  @include it("generates correct fallbacks with a single non-zero value for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "block")
+      }
+
+      @include expect {
+        padding-top: 16px;
+        padding-top: 1rem;
+        padding-bottom: 16px;
+        padding-bottom: 1rem;
+        padding-block: 1rem;
+      }
+
+    }
+  }
+
   //@include it("generates correct fallbacks with a pair of values for dimension 'block'") {
   //  @include assert() {
   //

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -3,144 +3,158 @@
 
 @include describe("padding [Mixin]") {
 
-  @include it("generates correct fallbacks with a single value and no dimension") {
+  @include it("generates correct fallbacks with a single zero value and no dimension") {
     @include assert() {
 
       @include output {
-        @include padding(16);
+        @include padding(0);
       }
 
       @include expect {
-        padding: 16px;
-        padding: 1rem;
+        padding: 0;
       }
 
     }
   }
 
-  @include it("generates correct fallbacks with a single value for dimension 'inline'") {
-    @include assert() {
+  //@include it("generates correct fallbacks with a single non-zero value and no dimension") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16);
+  //    }
+  //
+  //    @include expect {
+  //      padding: 16px;
+  //      padding: 1rem;
+  //    }
+  //
+  //  }
+  //}
 
-      @include output {
-        @include padding(16, "inline");
-      }
+  //@include it("generates correct fallbacks with a single value for dimension 'inline'") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16, "inline");
+  //    }
+  //
+  //    @include expect {
+  //      padding-left: 16px;
+  //      padding-left: 1rem;
+  //      padding-right: 16px;
+  //      padding-right: 1rem;
+  //      padding-inline: 1rem;
+  //    }
+  //
+  //  }
+  //}
 
-      @include expect {
-        padding-left: 16px;
-        padding-left: 1rem;
-        padding-right: 16px;
-        padding-right: 1rem;
-        padding-inline: 1rem;
-      }
-
-    }
-  }
-
-  @include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16 32, "inline");
-      }
-
-      @include expect {
-        &[dir="ltr"] {
-          padding-left: 16px;
-          padding-left: 1rem;
-          padding-right: 32px;
-          padding-right: 2rem;
-        }
-        &[dir="rtl"] {
-          padding-left: 32px;
-          padding-left: 2rem;
-          padding-right: 16px;
-          padding-right: 1rem;
-        }
-        padding-inline: 1rem 2rem;
-      }
-
-    }
-  }
-
-  @include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16, "inline-start");
-      }
-
-      @include expect {
-        &[dir="ltr"] {
-          padding-left: 16px;
-          padding-left: 1rem;
-        }
-        &[dir="rtl"] {
-          padding-right: 16px;
-          padding-right: 1rem;
-        }
-        padding-inline-start: 1rem;
-      }
-
-    }
-  }
-
-  @include it("generates correct fallbacks with a single value for the dimension 'inline-end'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16, "inline-end");
-      }
-
-      @include expect {
-        &[dir="ltr"] {
-          padding-right: 16px;
-          padding-right: 1rem;
-        }
-        &[dir="rtl"] {
-          padding-left: 16px;
-          padding-left: 1rem;
-        }
-        padding-inline-end: 1rem;
-      }
-
-    }
-  }
-
-  @include it("generates correct fallbacks with a single value for dimension 'block'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16, "block")
-      }
-
-      @include expect {
-        padding-top: 16px;
-        padding-top: 1rem;
-        padding-bottom: 16px;
-        padding-bottom: 1rem;
-        padding-block: 1rem;
-      }
-
-    }
-  }
-
-  @include it("generates correct fallbacks with a pair of values for dimension 'block'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16 32, "block")
-      }
-
-      @include expect {
-        padding-top: 16px;
-        padding-top: 1rem;
-        padding-bottom: 32px;
-        padding-bottom: 2rem;
-
-        padding-block: 1rem 2rem;
-      }
-
-    }
-  }
+  //@include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16 32, "inline");
+  //    }
+  //
+  //    @include expect {
+  //      &[dir="ltr"] {
+  //        padding-left: 16px;
+  //        padding-left: 1rem;
+  //        padding-right: 32px;
+  //        padding-right: 2rem;
+  //      }
+  //      &[dir="rtl"] {
+  //        padding-left: 32px;
+  //        padding-left: 2rem;
+  //        padding-right: 16px;
+  //        padding-right: 1rem;
+  //      }
+  //      padding-inline: 1rem 2rem;
+  //    }
+  //
+  //  }
+  //}
+  //
+  //@include it("generates correct fallbacks with a single value for the dimension 'inline-start'") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16, "inline-start");
+  //    }
+  //
+  //    @include expect {
+  //      &[dir="ltr"] {
+  //        padding-left: 16px;
+  //        padding-left: 1rem;
+  //      }
+  //      &[dir="rtl"] {
+  //        padding-right: 16px;
+  //        padding-right: 1rem;
+  //      }
+  //      padding-inline-start: 1rem;
+  //    }
+  //
+  //  }
+  //}
+  //
+  //@include it("generates correct fallbacks with a single value for the dimension 'inline-end'") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16, "inline-end");
+  //    }
+  //
+  //    @include expect {
+  //      &[dir="ltr"] {
+  //        padding-right: 16px;
+  //        padding-right: 1rem;
+  //      }
+  //      &[dir="rtl"] {
+  //        padding-left: 16px;
+  //        padding-left: 1rem;
+  //      }
+  //      padding-inline-end: 1rem;
+  //    }
+  //
+  //  }
+  //}
+  //
+  //@include it("generates correct fallbacks with a single value for dimension 'block'") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16, "block")
+  //    }
+  //
+  //    @include expect {
+  //      padding-top: 16px;
+  //      padding-top: 1rem;
+  //      padding-bottom: 16px;
+  //      padding-bottom: 1rem;
+  //      padding-block: 1rem;
+  //    }
+  //
+  //  }
+  //}
+  //
+  //@include it("generates correct fallbacks with a pair of values for dimension 'block'") {
+  //  @include assert() {
+  //
+  //    @include output {
+  //      @include padding(16 32, "block")
+  //    }
+  //
+  //    @include expect {
+  //      padding-top: 16px;
+  //      padding-top: 1rem;
+  //      padding-bottom: 32px;
+  //      padding-bottom: 2rem;
+  //
+  //      padding-block: 1rem 2rem;
+  //    }
+  //
+  //  }
+  //}
 
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -15,7 +15,20 @@
       }
 
     }
+
+    @include assert() {
+
+      @include output {
+        @include _padding-left(0);
+      }
+
+      @include expect {
+        padding-left: 0;
+      }
+
+    }
   }
+
 }
 
 @include describe('_padding-right [Mixin]') {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -18,6 +18,23 @@
   }
 }
 
+@include describe('_padding-right [Mixin]') {
+  @include it('generates expected padding-right declaration with appropriate fallbacks') {
+    @include assert() {
+
+      @include output {
+        @include _padding-right(16);
+      }
+
+      @include expect {
+        padding-right: 16px;
+        padding-right: 1rem;
+      }
+
+    }
+  }
+}
+
 @include describe("padding [Mixin]") {
 
   @include it("generates correct fallbacks with a single zero value and no dimension") {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -248,6 +248,30 @@
   }
 }
 
+  @include it("Ignores more than one value in the sizes list for the dimension 'inline-start'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32, "inline-start");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+        }
+        &[dir="rtl"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        &:not([data-never-use-this-data-attribute-name-in-html]) {
+          padding-inline-start: 1rem;
+        }
+      }
+
+    }
+  }
+
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-end'") {
     @include assert() {
 

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -162,6 +162,29 @@
     }
   }
 
+  @include it("generates correct fallbacks with a single non-zero value for the dimension 'inline-end'") {
+    @include assert() {
+
+     @include output {
+       @include padding(16, "inline-end");
+     }
+
+     @include expect {
+       &[dir="ltr"] {
+         padding-right: 16px;
+         padding-right: 1rem;
+       }
+       &[dir="rtl"] {
+         padding-left: 16px;
+         padding-left: 1rem;
+       }
+       &:not([data-never-use-this-data-attribute-name-in-html]) {
+        padding-inline-end: 1rem;
+       }
+     }
+   }
+}
+
   //@include it("generates correct fallbacks with a single value for dimension 'block'") {
   //  @include assert() {
   //

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -1,66 +1,6 @@
 @import "../../node_modules/sass-true/sass/true";
 @import "../../source/css/sass/_mixins--spacing.scss";
 
-@include describe('_padding-left [Mixin]') {
-  @include it('generates expected padding-left declaration with appropriate fallbacks') {
-    @include assert() {
-
-      @include output {
-        @include _padding-left(16);
-      }
-
-      @include expect {
-        padding-left: 16px;
-        padding-left: 1rem;
-      }
-
-    }
-
-    @include assert() {
-
-      @include output {
-        @include _padding-left(0);
-      }
-
-      @include expect {
-        padding-left: 0;
-      }
-
-    }
-  }
-
-}
-
-@include describe('_padding-right [Mixin]') {
-  @include it('generates expected padding-right declaration with appropriate fallbacks') {
-    @include assert() {
-
-      @include output {
-        @include _padding-right(16);
-      }
-
-      @include expect {
-        padding-right: 16px;
-        padding-right: 1rem;
-      }
-
-    }
-
-    @include assert() {
-
-      @include output {
-        @include _padding-right(0);
-      }
-
-      @include expect {
-        padding-right: 0;
-      }
-
-    }
-
-  }
-}
-
 @include describe("padding [Mixin]") {
 
   @include it("generates correct fallbacks with a single zero value and no dimension") {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -407,4 +407,21 @@
     }
   }
 
+  @include it("Ignores more than two values in the sizes list for the dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16 32 48, "block");
+      }
+
+      @include expect {
+          padding-top: 16px;
+          padding-top: 1rem;
+          padding-bottom: 32px;
+          padding-bottom: 2rem;
+          padding-block: 1rem 2rem;
+      }
+    }
+  }
+
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -126,7 +126,7 @@
     }
   }
 
-  @include it("generates correct fallbacks with a pair of different values for dimension 'inline'") {
+  @include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
     @include assert() {
 
       @include output {
@@ -153,7 +153,92 @@
       }
 
     }
+
+    @include assert() {
+
+      @include output {
+        @include padding(16 16, "inline");
+      }
+
+      @include expect {
+        padding-left: 16px;
+        padding-left: 1rem;
+        padding-right: 16px;
+        padding-right: 1rem;
+
+        // TODO: "padding-inline: 1rem;" is better here:
+        padding-inline: 1rem 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(0 32, "inline");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-left: 0;
+          padding-right: 32px;
+          padding-right: 2rem;
+        }
+        &[dir="rtl"] {
+          padding-right: 0;
+          padding-left: 32px;
+          padding-left: 2rem;
+        }
+
+        &:not([data-never-use-this-data-attribute-name-in-html]) {
+          padding-inline: 0 2rem;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(16 0, "inline");
+      }
+
+      @include expect {
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+          padding-right: 0;
+        }
+        &[dir="rtl"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+          padding-left: 0;
+        }
+
+        &:not([data-never-use-this-data-attribute-name-in-html]) {
+          padding-inline: 1rem 0;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(0 0, "inline");
+      }
+
+      @include expect {
+        padding-left: 0;
+        padding-right: 0;
+        // TODO: "padding-inline: 0 0;" is better here:
+        padding-inline: 0 0;
+        }
+
+    }
   }
+
+  // TODO: what happens when passed "inline" but a list of > 2 values?
 
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
    @include assert() {

--- a/test/sass/test_sass.js
+++ b/test/sass/test_sass.js
@@ -1,6 +1,16 @@
 const path = require('path');
 const sassTrue = require('sass-true');
 
-const sassFile = path.join(__dirname, 'utility-functions.spec.scss');
-sassTrue.runSass({file: sassFile}, describe, it);
+// TODO: derive from directory listing rather than explicitly describing
+[
+  'utility-functions.spec.scss',
+  'mixins--spacing.spec.scss'
+].forEach((filename) => {
+  sassTrue.runSass(
+    {
+      file: path.join(__dirname, filename)
+    },
+    describe,
+    it);
+});
 


### PR DESCRIPTION
Replaces eLife `padding` mixin with new TDD-generated Libero `padding` mixin. This new mixin expects CSS logical properties for its optional dimension argument, and handles appropriate fallbacks. 

These fallbacks rely on:
- an appropriate `dir` attribute always being set on the `<html>` element
- if a direction change is described by `dir` on another element within the document, every one of its descendant HTML elements must have the appropriate `dir` attribute set.

Note that we're primarily concerned with text direction along the horizontal axis for now, as vertical writing directions are more complicated, and to support them properly we need specialist expertise.