### PR TITLE
Run gulp through Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: minimal
 
 services: docker
 
-branches:
-    only:
-        - master
-
 script:
     # conventional image name, but no intention to push it so far
     - docker build -t liberoadmin/patterns-core .
@@ -16,3 +12,9 @@ after_success:
     - docker run --name patterns-core liberoadmin/patterns-core node_modules/.bin/gulp exportPatterns
     # TODO: empty out committed export/ folder
     - docker cp patterns-core:/patterns-core/export/. export/
+
+if: |
+    branch = master OR \
+    branch =~ /^[0-9\.]+$/ OR \
+    tag IS present OR \
+    type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: minimal
+
+services: docker
+
+branches:
+    only:
+        - master
+
+script:
+    # conventional image name, but no intention to push it so far
+    - docker build -t liberoadmin/patterns-core .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ script:
 
 after_success:
     - docker run --name patterns-core liberoadmin/patterns-core node_modules/.bin/gulp exportPatterns
+    # TODO: empty out committed export/ folder
     - docker cp patterns-core:/patterns-core/export/. export/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ branches:
 script:
     # conventional image name, but no intention to push it so far
     - docker build -t liberoadmin/patterns-core .
+
+after_success:
+    - docker run --name patterns-core liberoadmin/patterns-core node_modules/.bin/gulp exportPatterns
+    - docker cp patterns-core:/patterns-core/export/. export/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-jessie
+FROM node:8.12.0-slim
 WORKDIR /patterns-core
 
 COPY package.json package-lock.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 COPY . ./
-RUN node_modules/.bin/gulp
+RUN node_modules/.bin/gulp build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:8.12.0-jessie
+WORKDIR /patterns-core
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY . ./
+RUN node_modules/.bin/gulp

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 Libero pattern library
 ======================
+
+## Pipeline
+
+The build process uses a Node.js container image to build all assets, and copy them out of the container into `export/`.
+
+`export/` can then be packaged to be released on Github, or reused elsewhere.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,7 +118,7 @@ gulp.task('patternsExport:clean', () => {
   del([`${config.exportRoot}**/*`]);
 });
 
-gulp.task('exportPatterns', ['build', 'patternsExport:clean'], () => {
+gulp.task('exportPatterns', ['patternsExport:clean'], () => {
 
   gulp.src(config.files.src.css)
       .pipe(gulp.dest(config.dir.out.css));
@@ -139,4 +139,4 @@ gulp.task('exportPatterns', ['build', 'patternsExport:clean'], () => {
 
 });
 
-gulp.task('default', ['exportPatterns']);
+gulp.task('default', ['build', 'exportPatterns']);


### PR DESCRIPTION
Part of https://github.com/libero/libero/issues/37

The testing process is not separated from the build process at the moment, so we do everything but the export within the Docker container build process. Files will be extracted from there for packaging.