### PR TITLE
Deploy tags as Github releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /source/css/*.map
 /vendor/
 /.sass-cache/
+/patterns-core-*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,17 @@ after_success:
     - docker run --name patterns-core liberoadmin/patterns-core node_modules/.bin/gulp exportPatterns
     # TODO: empty out committed export/ folder
     - docker cp patterns-core:/patterns-core/export/. export/
+    - .travis/package.sh
+
+deploy:
+  provider: releases
+  api_key:
+    # Github token from user `liberoadmin` with `public_repo` scope
+    secure: WioMaGj+sjvtVdZgYOPyEm0d/mAbqO/xanNgz+ckXai1py55xWpr/gZl5Wkncbt8fQQnHLPUiYzakENBk7zJ0H3sH6m/v60kHmJ5bFmTNYS7kepeu98eWfPUXcmZ+qWhJ4BSFU/LEreOmIsIbgK8W48JVhiGIY7kIk2VgN7Bv3sgyJzm23edMth/jbiwJBMWww8vWIaRyiv1BTQPSwQXbmg+nbvE8NmIftkX4AXQsTfIfrmpfTgOebLVIgdYSN3GWiQDp0fU09laGvws4z1JlK+zf+AzkeFnXn6IsdkPbznpBFhjndTq0afgecwIh9KpJ03M0gQMBE/s1d5sIug8SmV3lgC/OpyqLyzfu941Ehda56jbnR5nh7oBhaWel7ae4E98rkZLMaLEH0aTFD/8vYYxq8A0sObIzoi7y5pc9+0xA/B2hzlPIrNJ4aUxO1v1jlIfa+yp553hrek7LlDqV9ngnwWRTnn8AC3WaZ9XNysp3gbf4koZiS9pzTeSku9ug2f1A22zeyygU8RIIc+uaj1t1w1v/cpGSQwbd//oqBFPvbzpf0gS7E1fqUkkHvg641FA7FCn1fYJPEdDFhSQS69G79vRe5X+mEeAPb5TZ7CGmuTKUoDmndgoFooUr0sd9VhKjlFxdtc7bMMY5oRibyqpYs5gT04Og9SxVs+GCfg=
+  file: "patterns-core-${TRAVIS_TAG}.tar.gz"
+  skip_cleanup: true
+  on:
+    tags: true
 
 if: |
     branch = master OR \

--- a/.travis/package.sh
+++ b/.travis/package.sh
@@ -1,0 +1,12 @@
+#!/bin/bash 
+set -e
+
+filename="patterns-core-${TRAVIS_TAG:-master}.tar.gz"
+rm -f "$filename"
+tar -czf "$filename" \
+    -C export/ \
+    css \
+    fonts \
+    images \
+    templates
+echo "Created $filename"


### PR DESCRIPTION
Should create an archive at https://github.com/libero/patterns-core/releases

Difficult to test outside of `master`.

[Sample: patterns-core-master.tar.gz](https://github.com/libero/patterns-core/files/2405649/patterns-core-master.tar.gz) (`master` would normally be the tag e.g. `v0.0.1alpha1`)
