### PR TITLE
Rewrite CSS margin and nospace mixins to use logical properties

### DIFF
--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -87,11 +87,21 @@
     }
 
     @if $dimension == "inline" {
+      @if length($sizes-in-px) > 2 {
+        @error "More than two lengths supplied as $sizes-in-px argument to _spacing mixin with dimension 'inline'";
+      }
       @if $sizes-in-px == 0 {
         #{$space-type}-left: 0;
         #{$space-type}-right: 0;
         #{$space-type}-inline: 0;
-      } @else if type_of($sizes-in-px) == list and length($sizes-in-px) >= 2 {
+
+      } @else if length($sizes-in-px) == 1 {
+
+        @include _spacing-left($sizes-in-px, $space-type);
+        @include _spacing-right($sizes-in-px, $space-type);
+        #{$space-type}-inline: #{get-rem-from-px($sizes-in-px)}rem;
+
+      } @else {
 
         $firstValue: nth($sizes-in-px, 1);
         $secondValue: nth($sizes-in-px, 2);
@@ -131,12 +141,6 @@
             #{$space-type}-inline: $derivedFirstValue $derivedSecondValue;
           }
         }
-
-      } @else {
-
-        @include _spacing-left($sizes-in-px, $space-type);
-        @include _spacing-right($sizes-in-px, $space-type);
-        #{$space-type}-inline: #{get-rem-from-px($sizes-in-px)}rem;
 
       }
     }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -86,9 +86,7 @@
     }
 
     @if $dimension == "inline" {
-      @if length($sizes-in-px) > 2 {
-        @error "More than two lengths supplied as $sizes-in-px argument to _spacing mixin with dimension 'inline'";
-      }
+      $validation-status: validate-spacing-arguments($sizes-in-px, "inline");
       @if $sizes-in-px == 0 {
         #{$space-type}-left: 0;
         #{$space-type}-right: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -60,6 +60,9 @@
     @error "_spacing mixin $space-type argument must be exactly one of 'padding' or 'margin'";
   } @else {
     @if $dimension == "" {
+      @if length($sizes-in-px) > 4 {
+        @error "More than four lengths supplied as $size-in-px argument to _spacing mixin";
+      }
       @if $sizes-in-px == 0 {
         #{$space-type}: 0;
       } @else {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -232,7 +232,6 @@
 
 @mixin padding($sizes-in-px, $dimension: "") {
   @include _spacing($sizes-in-px, padding, $dimension);
-
 }
 
 @mixin margin($sizes-in-px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -203,6 +203,10 @@
 
     // Vertical writing modes not yet supported
     @if $dimension == "block" {
+      @if length($sizes-in-px) > 2 {
+        @error "More than two lengths supplied as $sizes-in-px argument to _spacing mixin with dimension 'block'";
+      }
+
       @if $sizes-in-px == 0 {
         #{$space-type}-top: 0;
         #{$space-type}-bottom: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -205,7 +205,7 @@
 }
 
 @mixin nospace($dimension: "all") {
-  $allowed-dimensions: "inline";
+  $allowed-dimensions: "inline", "inline-start";
   @if index($allowed-dimensions, $dimension) != null {
     @include margin(0, $dimension);
     @include padding(0, $dimension);

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -209,6 +209,12 @@
   @if index($allowed-dimensions, $dimension) != null {
     @include margin(0, $dimension);
     @include padding(0, $dimension);
+  } @else if $dimension == "block-start" {
+    //vertical writing modes not yet supported
+    margin-top: 0;
+    margin-block-start: 0;
+    padding-top: 0;
+    padding-block-start: 0;
   }
 }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -57,7 +57,7 @@
 //</div>
 @mixin _spacing($size-in-px, $space-type, $dimension: "") {
   @if $space-type != padding and $space-type != margin {
-    // This is for padding only
+    @error "_spacing mixin $space-type argument must be exactly one of 'padding' or 'margin'";
   } @else {
     @if $dimension == "" {
       @if $size-in-px == 0 {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -205,21 +205,10 @@
 }
 
 @mixin nospace($dimension: "all") {
-  @if $dimension == "all" {
-    margin: 0;
-    padding: 0;
-  } @else if $dimension == "top" {
-    margin-top: 0;
-    padding-top: 0;
-  } @else if $dimension == "right" {
-    margin-right: 0;
-    padding-right: 0;
-  } @else if $dimension == "bottom" {
-    margin-bottom: 0;
-    padding-bottom: 0;
-  } @else if $dimension == "left" {
-    margin-left: 0;
-    padding-left: 0;
+  $allowed-dimensions: "inline";
+  @if index($allowed-dimensions, $dimension) != null {
+    @include margin(0, $dimension);
+    @include padding(0, $dimension);
   }
 }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -215,6 +215,12 @@
     margin-block-start: 0;
     padding-top: 0;
     padding-block-start: 0;
+  } @else if $dimension == "block-end" {
+    //vertical writing modes not yet supported
+    margin-bottom: 0;
+    margin-block-end: 0;
+    padding-bottom: 0;
+    padding-block-end: 0;
   }
 }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -212,6 +212,17 @@
       #{$space-type}-block: #{get-rem-from-px($sizes-in-px)}rem;
     }
   }
+
+  @if $dimension == "block-start" {
+    @if $sizes-in-px == 0 {
+      #{$space-type}-top: #{$sizes-in-px};
+      #{$space-type}-block-start: #{$sizes-in-px};
+    } @else {
+      #{$space-type}-top: #{$sizes-in-px}px;
+      #{$space-type}-top: #{get-rem-from-px($sizes-in-px)}rem;
+      #{$space-type}-block-start: #{get-rem-from-px($sizes-in-px)}rem;
+    }
+  }
 }
 
 @mixin padding($sizes-in-px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -35,6 +35,25 @@
   }
 }
 
+@mixin _construct-dimensionless-space($sizes-in-px, $space-type) {
+  $parts-px: ();
+  $parts-rem: ();
+  @each $size in $sizes-in-px {
+    @if $size == 0 {
+      $parts-px: append($parts-px, #{$size}, "space");
+      $parts-rem: append($parts-rem, #{$size}, "space");
+    } @else {
+      $parts-px: append($parts-px, #{$size}px, "space");
+      $parts-rem: append($parts-rem, #{get-rem-from-px($size)}rem, "space");
+    }
+  }
+
+  #{$space-type}: $parts-px;
+  @if $parts-rem != $parts-px {
+    #{$space-type}: $parts-rem;
+  }
+}
+
 // Fallbacks for CSS logical properties contained within this mixin require the following treatment of HTML dir attributes:
 //  - document level: always specified, via the HTML element
 //  - block level: specified on every element within a block describing a direction switch.
@@ -59,17 +78,14 @@
   @if $space-type != padding and $space-type != margin {
     @error "_spacing mixin $space-type argument must be exactly one of 'padding' or 'margin'";
   } @else {
+
     @if $dimension == "" {
       @if length($sizes-in-px) > 4 {
-        @error "More than four lengths supplied as $size-in-px argument to _spacing mixin";
+        @error "More than four lengths supplied as $sizes-in-px argument to _spacing mixin";
       }
-      @if $sizes-in-px == 0 {
-        #{$space-type}: 0;
-      } @else {
-        #{$space-type}: #{$sizes-in-px}px;
-        #{$space-type}: #{get-rem-from-px($sizes-in-px)}rem;
-      }
+      @include _construct-dimensionless-space($sizes-in-px, $space-type);
     }
+
     @if $dimension == "inline" {
       @if $sizes-in-px == 0 {
         #{$space-type}-left: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -193,9 +193,6 @@
 
     // Vertical writing modes not yet supported
     @if $dimension == "block" {
-      @if length($sizes-in-px) > 2 {
-        @error "More than two lengths supplied as $sizes-in-px argument to _spacing mixin with dimension 'block'";
-      }
 
       @if $sizes-in-px == 0 {
         #{$space-type}-top: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -36,6 +36,8 @@
 }
 
 @mixin _construct-dimensionless-space($sizes-in-px, $space-type) {
+  $validation-status: validate-spacing-arguments($sizes-in-px);
+
   $parts-px: ();
   $parts-rem: ();
   @each $size in $sizes-in-px {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -204,8 +204,8 @@
   @include _spacing($size_in_px, margin, $dimension);
 }
 
-@mixin nospace($dimension: "all") {
-  $allowed-dimensions: "inline", "inline-start", "inline-end", "block";
+@mixin nospace($dimension: "") {
+  $allowed-dimensions: "inline", "inline-start", "inline-end", "block", "";
   @if index($allowed-dimensions, $dimension) != null {
     @include margin(0, $dimension);
     @include padding(0, $dimension);

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -146,6 +146,10 @@
     }
 
     @if $dimension == "inline-start" {
+      @if length($sizes-in-px) != 1 {
+        @error "Exactly one length must be supplied as $sizes-in-px argument to _spacing mixin with dimension 'inline-start'";
+      }
+
       @if $sizes-in-px == 0 {
         @include _when-left-to-right {
           #{$space-type}-left: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -82,9 +82,6 @@
   } @else {
 
     @if $dimension == "" {
-      @if length($sizes-in-px) > 4 {
-        @error "More than four lengths supplied as $sizes-in-px argument to _spacing mixin";
-      }
       @include _construct-dimensionless-space($sizes-in-px, $space-type);
     }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -167,9 +167,6 @@
     }
 
     @if $dimension == "inline-end" {
-      @if length($sizes-in-px) != 1 {
-        @error "Exactly one length must be supplied as $sizes-in-px argument to _spacing mixin with dimension 'inline-end'";
-      }
 
       @if $sizes-in-px == 0 {
         @include _when-left-to-right {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -3,21 +3,21 @@
 
 // NOTE: mixins beginning with underscore "_" are internal to this file only: they MUST NOT be used externally.
 
-@mixin _padding-left($size-in-px) {
+@mixin _spacing-left($size-in-px, $space-type) {
   @if $size-in-px == 0 {
-    padding-left: 0;
+    #{$space-type}-left: 0;
   } @else {
-    padding-left: #{$size_in_px}px;
-    padding-left: #{get-rem-from-px($size_in_px)}rem;
+    #{$space-type}-left: #{$size_in_px}px;
+    #{$space-type}-left: #{get-rem-from-px($size_in_px)}rem;
   }
 }
 
-@mixin _padding-right($size-in-px) {
+@mixin _spacing-right($size-in-px, $space-type) {
   @if $size-in-px == 0 {
-    padding-right: 0;
+    #{$space-type}-right: 0;
   } @else {
-    padding-right: #{$size_in_px}px;
-    padding-right: #{get-rem-from-px($size_in_px)}rem;
+    #{$space-type}-right: #{$size_in_px}px;
+    #{$space-type}-right: #{get-rem-from-px($size_in_px)}rem;
   }
 }
 
@@ -77,25 +77,23 @@
         $firstValue: nth($size_in_px, 1);
         $secondValue: nth($size_in_px, 2);
 
-        @if $space_type == padding {
-          @if $firstValue == $secondValue {
+        @if $firstValue == $secondValue {
 
-            @include _padding-left($firstValue);
-            @include _padding-right($secondValue);
+          @include _spacing-left($firstValue, $space_type);
+          @include _spacing-right($secondValue, $space_type);
 
-          } @else {
+        } @else {
 
-            @include _when-left-to-right {
-              @include _padding-left($firstValue);
-              @include _padding-right($secondValue);
-            }
-
-            @include _when-right-to-left {
-              @include _padding-right($firstValue);
-              @include _padding-left($secondValue);
-            }
-
+          @include _when-left-to-right {
+            @include _spacing-left($firstValue, $space_type);
+            @include _spacing-right($secondValue, $space_type);
           }
+
+          @include _when-right-to-left {
+            @include _spacing-right($firstValue, $space_type);
+            @include _spacing-left($secondValue, $space_type);
+          }
+
         }
 
         $derivedFirstValue: 0;
@@ -116,10 +114,9 @@
         }
 
       } @else {
-        @if $space_type == padding {
-          @include _padding-left($size_in_px);
-          @include _padding-right($size_in_px);
-        }
+
+        @include _spacing-left($size_in_px, $space_type);
+        @include _spacing-right($size_in_px, $space_type);
         #{$space_type}-inline: #{get-rem-from-px($size_in_px)}rem;
 
       }
@@ -138,14 +135,10 @@
         }
       } @else {
         @include _when-left-to-right {
-          @if $space_type == padding {
-            @include _padding-left(nth($size_in_px, 1));
-          }
+          @include _spacing-left(nth($size_in_px, 1), $space_type);
         }
         @include _when-right-to-left {
-          @if $space_type == padding {
-            @include _padding-right(nth($size_in_px, 1));
-          }
+          @include _spacing-right(nth($size_in_px, 1), $space_type);
         }
         html[dir] & {
           #{$space_type}-inline-start: #{get-rem-from-px(nth($size_in_px, 1))}rem;
@@ -166,14 +159,10 @@
         }
       } @else {
         @include _when-left-to-right {
-          @if $space_type == padding {
-            @include _padding-right(nth($size_in_px, 1));
-          }
+          @include _spacing-right(nth($size_in_px, 1), $space_type);
         }
         @include _when-right-to-left {
-          @if $space_type == padding {
-            @include _padding-left(nth($size_in_px, 1));
-          }
+          @include _spacing-left(nth($size_in_px, 1), $space_type);
         }
         html[dir] & {
           #{$space_type}-inline-end: #{get-rem-from-px(nth($size_in_px, 1))}rem;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -55,27 +55,27 @@
 //  <div class="test" dir="ltr">But obviously also when it does.</div>
 //
 //</div>
-@mixin _spacing($size-in-px, $space-type, $dimension: "") {
+@mixin _spacing($sizes-in-px, $space-type, $dimension: "") {
   @if $space-type != padding and $space-type != margin {
     @error "_spacing mixin $space-type argument must be exactly one of 'padding' or 'margin'";
   } @else {
     @if $dimension == "" {
-      @if $size-in-px == 0 {
+      @if $sizes-in-px == 0 {
         #{$space-type}: 0;
       } @else {
-        #{$space-type}: #{$size-in-px}px;
-        #{$space-type}: #{get-rem-from-px($size-in-px)}rem;
+        #{$space-type}: #{$sizes-in-px}px;
+        #{$space-type}: #{get-rem-from-px($sizes-in-px)}rem;
       }
     }
     @if $dimension == "inline" {
-      @if $size-in-px == 0 {
+      @if $sizes-in-px == 0 {
         #{$space-type}-left: 0;
         #{$space-type}-right: 0;
         #{$space-type}-inline: 0;
-      } @else if type_of($size-in-px) == list and length($size-in-px) >= 2 {
+      } @else if type_of($sizes-in-px) == list and length($sizes-in-px) >= 2 {
 
-        $firstValue: nth($size-in-px, 1);
-        $secondValue: nth($size-in-px, 2);
+        $firstValue: nth($sizes-in-px, 1);
+        $secondValue: nth($sizes-in-px, 2);
 
         @if $firstValue == $secondValue {
 
@@ -115,15 +115,15 @@
 
       } @else {
 
-        @include _spacing-left($size-in-px, $space-type);
-        @include _spacing-right($size-in-px, $space-type);
-        #{$space-type}-inline: #{get-rem-from-px($size-in-px)}rem;
+        @include _spacing-left($sizes-in-px, $space-type);
+        @include _spacing-right($sizes-in-px, $space-type);
+        #{$space-type}-inline: #{get-rem-from-px($sizes-in-px)}rem;
 
       }
     }
 
     @if $dimension == "inline-start" {
-      @if $size-in-px == 0 {
+      @if $sizes-in-px == 0 {
         @include _when-left-to-right {
           #{$space-type}-left: 0;
         }
@@ -135,19 +135,19 @@
         }
       } @else {
         @include _when-left-to-right {
-          @include _spacing-left(nth($size-in-px, 1), $space-type);
+          @include _spacing-left(nth($sizes-in-px, 1), $space-type);
         }
         @include _when-right-to-left {
-          @include _spacing-right(nth($size-in-px, 1), $space-type);
+          @include _spacing-right(nth($sizes-in-px, 1), $space-type);
         }
         html[dir] & {
-          #{$space-type}-inline-start: #{get-rem-from-px(nth($size-in-px, 1))}rem;
+          #{$space-type}-inline-start: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
         }
       }
     }
 
     @if $dimension == "inline-end" {
-      @if $size-in-px == 0 {
+      @if $sizes-in-px == 0 {
         @include _when-left-to-right {
           #{$space-type}-right: 0;
         }
@@ -159,49 +159,49 @@
         }
       } @else {
         @include _when-left-to-right {
-          @include _spacing-right(nth($size-in-px, 1), $space-type);
+          @include _spacing-right(nth($sizes-in-px, 1), $space-type);
         }
         @include _when-right-to-left {
-          @include _spacing-left(nth($size-in-px, 1), $space-type);
+          @include _spacing-left(nth($sizes-in-px, 1), $space-type);
         }
         html[dir] & {
-          #{$space-type}-inline-end: #{get-rem-from-px(nth($size-in-px, 1))}rem;
+          #{$space-type}-inline-end: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
         }
       }
     }
 
     // Vertical writing modes not yet supported
     @if $dimension == "block" {
-      @if $size-in-px == 0 {
+      @if $sizes-in-px == 0 {
         #{$space-type}-top: 0;
         #{$space-type}-bottom: 0;
         #{$space-type}-block: 0;
 
-      } @else if type_of($size-in-px) == list and length($size-in-px) >= 2 {
-        #{$space-type}-top: #{nth($size-in-px, 1)}px;
-        #{$space-type}-top: #{get-rem-from-px(nth($size-in-px, 1))}rem;
-        #{$space-type}-bottom: #{nth($size-in-px, 2)}px;
-        #{$space-type}-bottom: #{get-rem-from-px(nth($size-in-px, 2))}rem;
-        #{$space-type}-block: #{get-rem-from-px(nth($size-in-px, 1))}rem #{get-rem-from-px(nth($size-in-px, 2))}rem;;
+      } @else if type_of($sizes-in-px) == list and length($sizes-in-px) >= 2 {
+        #{$space-type}-top: #{nth($sizes-in-px, 1)}px;
+        #{$space-type}-top: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
+        #{$space-type}-bottom: #{nth($sizes-in-px, 2)}px;
+        #{$space-type}-bottom: #{get-rem-from-px(nth($sizes-in-px, 2))}rem;
+        #{$space-type}-block: #{get-rem-from-px(nth($sizes-in-px, 1))}rem #{get-rem-from-px(nth($sizes-in-px, 2))}rem;;
 
       } @else {
-        #{$space-type}-top: #{$size-in-px}px;
-        #{$space-type}-top: #{get-rem-from-px($size-in-px)}rem;
-        #{$space-type}-bottom: #{$size-in-px}px;
-        #{$space-type}-bottom: #{get-rem-from-px($size-in-px)}rem;
-        #{$space-type}-block: #{get-rem-from-px($size-in-px)}rem;
+        #{$space-type}-top: #{$sizes-in-px}px;
+        #{$space-type}-top: #{get-rem-from-px($sizes-in-px)}rem;
+        #{$space-type}-bottom: #{$sizes-in-px}px;
+        #{$space-type}-bottom: #{get-rem-from-px($sizes-in-px)}rem;
+        #{$space-type}-block: #{get-rem-from-px($sizes-in-px)}rem;
       }
     }
   }
 }
 
-@mixin padding($size-in-px, $dimension: "") {
-  @include _spacing($size-in-px, padding, $dimension);
+@mixin padding($sizes-in-px, $dimension: "") {
+  @include _spacing($sizes-in-px, padding, $dimension);
 
 }
 
-@mixin margin($size-in-px, $dimension: "") {
-  @include _spacing($size-in-px, margin, $dimension);
+@mixin margin($sizes-in-px, $dimension: "") {
+  @include _spacing($sizes-in-px, margin, $dimension);
 }
 
 @mixin nospace($dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -205,7 +205,7 @@
 }
 
 @mixin nospace($dimension: "all") {
-  $allowed-dimensions: "inline", "inline-start";
+  $allowed-dimensions: "inline", "inline-start", "inline-end";
   @if index($allowed-dimensions, $dimension) != null {
     @include margin(0, $dimension);
     @include padding(0, $dimension);

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -174,6 +174,10 @@
     }
 
     @if $dimension == "inline-end" {
+      @if length($sizes-in-px) != 1 {
+        @error "Exactly one length must be supplied as $sizes-in-px argument to _spacing mixin with dimension 'inline-end'";
+      }
+
       @if $sizes-in-px == 0 {
         @include _when-left-to-right {
           #{$space-type}-right: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -36,8 +36,6 @@
 }
 
 @mixin _construct-dimensionless-space($sizes-in-px, $space-type) {
-  $validation-status: validate-spacing-arguments($sizes-in-px);
-
   $parts-px: ();
   $parts-rem: ();
   @each $size in $sizes-in-px {
@@ -81,12 +79,13 @@
     @error "_spacing mixin $space-type argument must be exactly one of 'padding' or 'margin'";
   } @else {
 
+    $validation-status: validate-spacing-arguments($sizes-in-px, $dimension);
+
     @if $dimension == "" {
       @include _construct-dimensionless-space($sizes-in-px, $space-type);
     }
 
     @if $dimension == "inline" {
-      $validation-status: validate-spacing-arguments($sizes-in-px, "inline");
       @if $sizes-in-px == 0 {
         #{$space-type}-left: 0;
         #{$space-type}-right: 0;

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -7,8 +7,8 @@
   @if $size-in-px == 0 {
     #{$space-type}-left: 0;
   } @else {
-    #{$space-type}-left: #{$size_in_px}px;
-    #{$space-type}-left: #{get-rem-from-px($size_in_px)}rem;
+    #{$space-type}-left: #{$size-in-px}px;
+    #{$space-type}-left: #{get-rem-from-px($size-in-px)}rem;
   }
 }
 
@@ -16,8 +16,8 @@
   @if $size-in-px == 0 {
     #{$space-type}-right: 0;
   } @else {
-    #{$space-type}-right: #{$size_in_px}px;
-    #{$space-type}-right: #{get-rem-from-px($size_in_px)}rem;
+    #{$space-type}-right: #{$size-in-px}px;
+    #{$space-type}-right: #{get-rem-from-px($size-in-px)}rem;
   }
 }
 
@@ -55,43 +55,43 @@
 //  <div class="test" dir="ltr">But obviously also when it does.</div>
 //
 //</div>
-@mixin _spacing($size_in_px, $space_type, $dimension: "") {
-  @if $space_type != padding and $space_type != margin {
+@mixin _spacing($size-in-px, $space-type, $dimension: "") {
+  @if $space-type != padding and $space-type != margin {
     // This is for padding only
   } @else {
     @if $dimension == "" {
-      @if $size_in_px == 0 {
-        #{$space_type}: 0;
+      @if $size-in-px == 0 {
+        #{$space-type}: 0;
       } @else {
-        #{$space_type}: #{$size_in_px}px;
-        #{$space_type}: #{get-rem-from-px($size_in_px)}rem;
+        #{$space-type}: #{$size-in-px}px;
+        #{$space-type}: #{get-rem-from-px($size-in-px)}rem;
       }
     }
     @if $dimension == "inline" {
-      @if $size_in_px == 0 {
-        #{$space_type}-left: 0;
-        #{$space_type}-right: 0;
-        #{$space_type}-inline: 0;
-      } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
+      @if $size-in-px == 0 {
+        #{$space-type}-left: 0;
+        #{$space-type}-right: 0;
+        #{$space-type}-inline: 0;
+      } @else if type_of($size-in-px) == list and length($size-in-px) >= 2 {
 
-        $firstValue: nth($size_in_px, 1);
-        $secondValue: nth($size_in_px, 2);
+        $firstValue: nth($size-in-px, 1);
+        $secondValue: nth($size-in-px, 2);
 
         @if $firstValue == $secondValue {
 
-          @include _spacing-left($firstValue, $space_type);
-          @include _spacing-right($secondValue, $space_type);
+          @include _spacing-left($firstValue, $space-type);
+          @include _spacing-right($secondValue, $space-type);
 
         } @else {
 
           @include _when-left-to-right {
-            @include _spacing-left($firstValue, $space_type);
-            @include _spacing-right($secondValue, $space_type);
+            @include _spacing-left($firstValue, $space-type);
+            @include _spacing-right($secondValue, $space-type);
           }
 
           @include _when-right-to-left {
-            @include _spacing-right($firstValue, $space_type);
-            @include _spacing-left($secondValue, $space_type);
+            @include _spacing-right($firstValue, $space-type);
+            @include _spacing-left($secondValue, $space-type);
           }
 
         }
@@ -106,102 +106,102 @@
         }
 
         @if $firstValue == $secondValue {
-          #{$space_type}-inline: $derivedFirstValue;
+          #{$space-type}-inline: $derivedFirstValue;
         } @else {
           html[dir] & {
-            #{$space_type}-inline: $derivedFirstValue $derivedSecondValue;
+            #{$space-type}-inline: $derivedFirstValue $derivedSecondValue;
           }
         }
 
       } @else {
 
-        @include _spacing-left($size_in_px, $space_type);
-        @include _spacing-right($size_in_px, $space_type);
-        #{$space_type}-inline: #{get-rem-from-px($size_in_px)}rem;
+        @include _spacing-left($size-in-px, $space-type);
+        @include _spacing-right($size-in-px, $space-type);
+        #{$space-type}-inline: #{get-rem-from-px($size-in-px)}rem;
 
       }
     }
 
     @if $dimension == "inline-start" {
-      @if $size_in_px == 0 {
+      @if $size-in-px == 0 {
         @include _when-left-to-right {
-          #{$space_type}-left: 0;
+          #{$space-type}-left: 0;
         }
         @include _when-right-to-left {
-          #{$space_type}-right: 0;
+          #{$space-type}-right: 0;
         }
         html[dir] & {
-          #{$space_type}-inline-start: 0;
+          #{$space-type}-inline-start: 0;
         }
       } @else {
         @include _when-left-to-right {
-          @include _spacing-left(nth($size_in_px, 1), $space_type);
+          @include _spacing-left(nth($size-in-px, 1), $space-type);
         }
         @include _when-right-to-left {
-          @include _spacing-right(nth($size_in_px, 1), $space_type);
+          @include _spacing-right(nth($size-in-px, 1), $space-type);
         }
         html[dir] & {
-          #{$space_type}-inline-start: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+          #{$space-type}-inline-start: #{get-rem-from-px(nth($size-in-px, 1))}rem;
         }
       }
     }
 
     @if $dimension == "inline-end" {
-      @if $size_in_px == 0 {
+      @if $size-in-px == 0 {
         @include _when-left-to-right {
-          #{$space_type}-right: 0;
+          #{$space-type}-right: 0;
         }
         @include _when-right-to-left {
-          #{$space_type}-left: 0;
+          #{$space-type}-left: 0;
         }
         html[dir] & {
-          #{$space_type}-inline-end: 0;
+          #{$space-type}-inline-end: 0;
         }
       } @else {
         @include _when-left-to-right {
-          @include _spacing-right(nth($size_in_px, 1), $space_type);
+          @include _spacing-right(nth($size-in-px, 1), $space-type);
         }
         @include _when-right-to-left {
-          @include _spacing-left(nth($size_in_px, 1), $space_type);
+          @include _spacing-left(nth($size-in-px, 1), $space-type);
         }
         html[dir] & {
-          #{$space_type}-inline-end: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+          #{$space-type}-inline-end: #{get-rem-from-px(nth($size-in-px, 1))}rem;
         }
       }
     }
 
     // Vertical writing modes not yet supported
     @if $dimension == "block" {
-      @if $size_in_px == 0 {
-        #{$space_type}-top: 0;
-        #{$space_type}-bottom: 0;
-        #{$space_type}-block: 0;
+      @if $size-in-px == 0 {
+        #{$space-type}-top: 0;
+        #{$space-type}-bottom: 0;
+        #{$space-type}-block: 0;
 
-      } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
-        #{$space_type}-top: #{nth($size_in_px, 1)}px;
-        #{$space_type}-top: #{get-rem-from-px(nth($size_in_px, 1))}rem;
-        #{$space_type}-bottom: #{nth($size_in_px, 2)}px;
-        #{$space_type}-bottom: #{get-rem-from-px(nth($size_in_px, 2))}rem;
-        #{$space_type}-block: #{get-rem-from-px(nth($size_in_px, 1))}rem #{get-rem-from-px(nth($size_in_px, 2))}rem;;
+      } @else if type_of($size-in-px) == list and length($size-in-px) >= 2 {
+        #{$space-type}-top: #{nth($size-in-px, 1)}px;
+        #{$space-type}-top: #{get-rem-from-px(nth($size-in-px, 1))}rem;
+        #{$space-type}-bottom: #{nth($size-in-px, 2)}px;
+        #{$space-type}-bottom: #{get-rem-from-px(nth($size-in-px, 2))}rem;
+        #{$space-type}-block: #{get-rem-from-px(nth($size-in-px, 1))}rem #{get-rem-from-px(nth($size-in-px, 2))}rem;;
 
       } @else {
-        #{$space_type}-top: #{$size_in_px}px;
-        #{$space_type}-top: #{get-rem-from-px($size_in_px)}rem;
-        #{$space_type}-bottom: #{$size_in_px}px;
-        #{$space_type}-bottom: #{get-rem-from-px($size_in_px)}rem;
-        #{$space_type}-block: #{get-rem-from-px($size_in_px)}rem;
+        #{$space-type}-top: #{$size-in-px}px;
+        #{$space-type}-top: #{get-rem-from-px($size-in-px)}rem;
+        #{$space-type}-bottom: #{$size-in-px}px;
+        #{$space-type}-bottom: #{get-rem-from-px($size-in-px)}rem;
+        #{$space-type}-block: #{get-rem-from-px($size-in-px)}rem;
       }
     }
   }
 }
 
-@mixin padding($size_in_px, $dimension: "") {
-  @include _spacing($size_in_px, padding, $dimension);
+@mixin padding($size-in-px, $dimension: "") {
+  @include _spacing($size-in-px, padding, $dimension);
 
 }
 
-@mixin margin($size_in_px, $dimension: "") {
-  @include _spacing($size_in_px, margin, $dimension);
+@mixin margin($size-in-px, $dimension: "") {
+  @include _spacing($size-in-px, margin, $dimension);
 }
 
 @mixin nospace($dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -75,144 +75,141 @@
 //
 //</div>
 @mixin _spacing($sizes-in-px, $space-type, $dimension: "") {
-  @if $space-type != padding and $space-type != margin {
-    @error "_spacing mixin $space-type argument must be exactly one of 'padding' or 'margin'";
-  } @else {
 
-    $validation-status: validate-spacing-arguments($sizes-in-px, $dimension);
+  // $validation-status is throw away, it's only used to enable validate-spacing-arguments() function to be invoked
+  $validation-status: validate-spacing-arguments($sizes-in-px, $space-type, $dimension);
 
-    @if $dimension == "" {
-      @include _construct-dimensionless-space($sizes-in-px, $space-type);
-    }
+  @if $dimension == "" {
+    @include _construct-dimensionless-space($sizes-in-px, $space-type);
+  }
 
-    @if $dimension == "inline" {
-      @if $sizes-in-px == 0 {
-        #{$space-type}-left: 0;
-        #{$space-type}-right: 0;
-        #{$space-type}-inline: 0;
+  @if $dimension == "inline" {
+    @if $sizes-in-px == 0 {
+      #{$space-type}-left: 0;
+      #{$space-type}-right: 0;
+      #{$space-type}-inline: 0;
 
-      } @else if length($sizes-in-px) == 1 {
+    } @else if length($sizes-in-px) == 1 {
 
-        @include _spacing-left($sizes-in-px, $space-type);
-        @include _spacing-right($sizes-in-px, $space-type);
-        #{$space-type}-inline: #{get-rem-from-px($sizes-in-px)}rem;
+      @include _spacing-left($sizes-in-px, $space-type);
+      @include _spacing-right($sizes-in-px, $space-type);
+      #{$space-type}-inline: #{get-rem-from-px($sizes-in-px)}rem;
+
+    } @else {
+
+      $firstValue: nth($sizes-in-px, 1);
+      $secondValue: nth($sizes-in-px, 2);
+
+      @if $firstValue == $secondValue {
+
+        @include _spacing-left($firstValue, $space-type);
+        @include _spacing-right($secondValue, $space-type);
 
       } @else {
 
-        $firstValue: nth($sizes-in-px, 1);
-        $secondValue: nth($sizes-in-px, 2);
-
-        @if $firstValue == $secondValue {
-
+        @include _when-left-to-right {
           @include _spacing-left($firstValue, $space-type);
           @include _spacing-right($secondValue, $space-type);
-
-        } @else {
-
-          @include _when-left-to-right {
-            @include _spacing-left($firstValue, $space-type);
-            @include _spacing-right($secondValue, $space-type);
-          }
-
-          @include _when-right-to-left {
-            @include _spacing-right($firstValue, $space-type);
-            @include _spacing-left($secondValue, $space-type);
-          }
-
         }
 
-        $derivedFirstValue: 0;
-        $derivedSecondValue: 0;
-        @if $firstValue != 0 {
-          $derivedFirstValue: #{get-rem-from-px($firstValue)}rem;
-        }
-        @if $secondValue != 0 {
-          $derivedSecondValue: #{get-rem-from-px($secondValue)}rem;
+        @include _when-right-to-left {
+          @include _spacing-right($firstValue, $space-type);
+          @include _spacing-left($secondValue, $space-type);
         }
 
-        @if $firstValue == $secondValue {
-          #{$space-type}-inline: $derivedFirstValue;
-        } @else {
-          html[dir] & {
-            #{$space-type}-inline: $derivedFirstValue $derivedSecondValue;
-          }
-        }
+      }
 
+      $derivedFirstValue: 0;
+      $derivedSecondValue: 0;
+      @if $firstValue != 0 {
+        $derivedFirstValue: #{get-rem-from-px($firstValue)}rem;
+      }
+      @if $secondValue != 0 {
+        $derivedSecondValue: #{get-rem-from-px($secondValue)}rem;
+      }
+
+      @if $firstValue == $secondValue {
+        #{$space-type}-inline: $derivedFirstValue;
+      } @else {
+        html[dir] & {
+          #{$space-type}-inline: $derivedFirstValue $derivedSecondValue;
+        }
+      }
+
+    }
+  }
+
+  @if $dimension == "inline-start" {
+
+    @if $sizes-in-px == 0 {
+      @include _when-left-to-right {
+        #{$space-type}-left: 0;
+      }
+      @include _when-right-to-left {
+        #{$space-type}-right: 0;
+      }
+      html[dir] & {
+        #{$space-type}-inline-start: 0;
+      }
+    } @else {
+      @include _when-left-to-right {
+        @include _spacing-left(nth($sizes-in-px, 1), $space-type);
+      }
+      @include _when-right-to-left {
+        @include _spacing-right(nth($sizes-in-px, 1), $space-type);
+      }
+      html[dir] & {
+        #{$space-type}-inline-start: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
       }
     }
+  }
 
-    @if $dimension == "inline-start" {
+  @if $dimension == "inline-end" {
 
-      @if $sizes-in-px == 0 {
-        @include _when-left-to-right {
-          #{$space-type}-left: 0;
-        }
-        @include _when-right-to-left {
-          #{$space-type}-right: 0;
-        }
-        html[dir] & {
-          #{$space-type}-inline-start: 0;
-        }
-      } @else {
-        @include _when-left-to-right {
-          @include _spacing-left(nth($sizes-in-px, 1), $space-type);
-        }
-        @include _when-right-to-left {
-          @include _spacing-right(nth($sizes-in-px, 1), $space-type);
-        }
-        html[dir] & {
-          #{$space-type}-inline-start: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
-        }
+    @if $sizes-in-px == 0 {
+      @include _when-left-to-right {
+        #{$space-type}-right: 0;
+      }
+      @include _when-right-to-left {
+        #{$space-type}-left: 0;
+      }
+      html[dir] & {
+        #{$space-type}-inline-end: 0;
+      }
+    } @else {
+      @include _when-left-to-right {
+        @include _spacing-right(nth($sizes-in-px, 1), $space-type);
+      }
+      @include _when-right-to-left {
+        @include _spacing-left(nth($sizes-in-px, 1), $space-type);
+      }
+      html[dir] & {
+        #{$space-type}-inline-end: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
       }
     }
+  }
 
-    @if $dimension == "inline-end" {
+  // Vertical writing modes not yet supported
+  @if $dimension == "block" {
 
-      @if $sizes-in-px == 0 {
-        @include _when-left-to-right {
-          #{$space-type}-right: 0;
-        }
-        @include _when-right-to-left {
-          #{$space-type}-left: 0;
-        }
-        html[dir] & {
-          #{$space-type}-inline-end: 0;
-        }
-      } @else {
-        @include _when-left-to-right {
-          @include _spacing-right(nth($sizes-in-px, 1), $space-type);
-        }
-        @include _when-right-to-left {
-          @include _spacing-left(nth($sizes-in-px, 1), $space-type);
-        }
-        html[dir] & {
-          #{$space-type}-inline-end: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
-        }
-      }
-    }
+    @if $sizes-in-px == 0 {
+      #{$space-type}-top: 0;
+      #{$space-type}-bottom: 0;
+      #{$space-type}-block: 0;
 
-    // Vertical writing modes not yet supported
-    @if $dimension == "block" {
+    } @else if type_of($sizes-in-px) == list and length($sizes-in-px) >= 2 {
+      #{$space-type}-top: #{nth($sizes-in-px, 1)}px;
+      #{$space-type}-top: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
+      #{$space-type}-bottom: #{nth($sizes-in-px, 2)}px;
+      #{$space-type}-bottom: #{get-rem-from-px(nth($sizes-in-px, 2))}rem;
+      #{$space-type}-block: #{get-rem-from-px(nth($sizes-in-px, 1))}rem #{get-rem-from-px(nth($sizes-in-px, 2))}rem;;
 
-      @if $sizes-in-px == 0 {
-        #{$space-type}-top: 0;
-        #{$space-type}-bottom: 0;
-        #{$space-type}-block: 0;
-
-      } @else if type_of($sizes-in-px) == list and length($sizes-in-px) >= 2 {
-        #{$space-type}-top: #{nth($sizes-in-px, 1)}px;
-        #{$space-type}-top: #{get-rem-from-px(nth($sizes-in-px, 1))}rem;
-        #{$space-type}-bottom: #{nth($sizes-in-px, 2)}px;
-        #{$space-type}-bottom: #{get-rem-from-px(nth($sizes-in-px, 2))}rem;
-        #{$space-type}-block: #{get-rem-from-px(nth($sizes-in-px, 1))}rem #{get-rem-from-px(nth($sizes-in-px, 2))}rem;;
-
-      } @else {
-        #{$space-type}-top: #{$sizes-in-px}px;
-        #{$space-type}-top: #{get-rem-from-px($sizes-in-px)}rem;
-        #{$space-type}-bottom: #{$sizes-in-px}px;
-        #{$space-type}-bottom: #{get-rem-from-px($sizes-in-px)}rem;
-        #{$space-type}-block: #{get-rem-from-px($sizes-in-px)}rem;
-      }
+    } @else {
+      #{$space-type}-top: #{$sizes-in-px}px;
+      #{$space-type}-top: #{get-rem-from-px($sizes-in-px)}rem;
+      #{$space-type}-bottom: #{$sizes-in-px}px;
+      #{$space-type}-bottom: #{get-rem-from-px($sizes-in-px)}rem;
+      #{$space-type}-block: #{get-rem-from-px($sizes-in-px)}rem;
     }
   }
 }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -223,6 +223,17 @@
       #{$space-type}-block-start: #{get-rem-from-px($sizes-in-px)}rem;
     }
   }
+
+  @if $dimension == "block-end" {
+    @if $sizes-in-px == 0 {
+      #{$space-type}-bottom: #{$sizes-in-px};
+      #{$space-type}-block-end: #{$sizes-in-px};
+    } @else {
+      #{$space-type}-bottom: #{$sizes-in-px}px;
+      #{$space-type}-bottom: #{get-rem-from-px($sizes-in-px)}rem;
+      #{$space-type}-block-end: #{get-rem-from-px($sizes-in-px)}rem;
+    }
+  }
 }
 
 @mixin padding($sizes-in-px, $dimension: "") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -142,9 +142,6 @@
     }
 
     @if $dimension == "inline-start" {
-      @if length($sizes-in-px) != 1 {
-        @error "Exactly one length must be supplied as $sizes-in-px argument to _spacing mixin with dimension 'inline-start'";
-      }
 
       @if $sizes-in-px == 0 {
         @include _when-left-to-right {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -296,40 +296,40 @@
 
 @mixin blg-pad-top--small-to-medium {
 
-  @include blg-spacing("top", "small");
+  @include blg-spacing("block-start", "small");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("top", "medium");
+    @include blg-spacing("block-start", "medium");
   }
 
 }
 
 @mixin blg-pad-bottom--small-to-medium {
 
-  @include blg-spacing("bottom", "small");
+  @include blg-spacing("block-end", "small");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("bottom", "medium");
+    @include blg-spacing("block-end", "medium");
   }
 
 }
 
 @mixin blg-pad-top--large-to-extra-large {
 
-  @include blg-spacing("top", "large");
+  @include blg-spacing("block-start", "large");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("top", "extra-large");
+    @include blg-spacing("block-start", "extra-large");
   }
 
 }
 
 @mixin blg-pad-bottom--large-to-extra-large {
 
-  @include blg-spacing("bottom", "large");
+  @include blg-spacing("block-end", "large");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("bottom", "extra-large");
+    @include blg-spacing("block-end", "extra-large");
   }
 
 }
@@ -346,20 +346,20 @@
 
 @mixin blg-margin-bottom--medium-to-large {
 
-  @include blg-spacing("bottom", "medium", "margin");
+  @include blg-spacing("block-end", "medium", "margin");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("bottom", "large", "margin");
+    @include blg-spacing("block-end", "large", "margin");
   }
 
 }
 
 @mixin blg-margin-bottom--small-to-medium {
 
-  @include blg-spacing("bottom", "small", "margin");
+  @include blg-spacing("block-end", "small", "margin");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("bottom", "medium", "margin");
+    @include blg-spacing("block-end", "medium", "margin");
   }
 
 }
@@ -380,20 +380,20 @@
 
 @mixin h3-spacing() {
   margin: 0;
-  @include blg-spacing("top", "extra-small");
-  @include blg-spacing("bottom", "extra-small");
+  @include blg-spacing("block-start", "extra-small");
+  @include blg-spacing("block-end", "extra-small");
 }
 
 @mixin h4-spacing() {
   margin: 0;
-  @include blg-spacing("top", "extra-small");
-  @include blg-spacing("bottom", "extra-small");
+  @include blg-spacing("block-start", "extra-small");
+  @include blg-spacing("block-end", "extra-small");
 }
 
 @mixin h5-spacing() {
   margin: 0;
-  @include blg-spacing("top", "extra-small");
-  @include blg-spacing("bottom", "extra-small");
+  @include blg-spacing("block-start", "extra-small");
+  @include blg-spacing("block-end", "extra-small");
 }
 
 @mixin h6-spacing() {
@@ -404,9 +404,9 @@
 
 @mixin body-spacing() {
   margin: 0;
-  @include blg-spacing("bottom", "small", "margin");
+  @include blg-spacing("block-end", "small", "margin");
 }
 
 @mixin small-spacing() {
-  @include blg-spacing("bottom", "small");
+  @include blg-spacing("block-end", "small");
 }

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -55,137 +55,159 @@
 //  <div class="test" dir="ltr">But obviously also when it does.</div>
 //
 //</div>
-@mixin padding($size_in_px, $dimension: "") {
-  @if $dimension == "" {
-    @if $size_in_px == 0 {
-      padding: 0;
-    } @else {
-      padding: #{$size_in_px}px;
-      padding: #{get-rem-from-px($size_in_px)}rem;
+@mixin _spacing($size_in_px, $space_type, $dimension: "") {
+  @if $space_type != padding {
+    // This is for padding only
+  } @else {
+    @if $dimension == "" {
+      @if $size_in_px == 0 {
+        #{$space_type}: 0;
+      } @else {
+        #{$space_type}: #{$size_in_px}px;
+        #{$space_type}: #{get-rem-from-px($size_in_px)}rem;
+      }
     }
-  }
-  @if $dimension == "inline" {
-    @if $size_in_px == 0 {
-      padding-left: 0;
-      padding-right: 0;
-      padding-inline: 0;
-    } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
+    @if $dimension == "inline" {
+      @if $size_in_px == 0 {
+        #{$space_type}-left: 0;
+        #{$space_type}-right: 0;
+        #{$space_type}-inline: 0;
+      } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
 
-      $firstValue: nth($size_in_px, 1);
-      $secondValue: nth($size_in_px, 2);
+        $firstValue: nth($size_in_px, 1);
+        $secondValue: nth($size_in_px, 2);
 
-      @if $firstValue == $secondValue {
+        @if $space_type == padding {
+          @if $firstValue == $secondValue {
 
-        @include _padding-left($firstValue);
-        @include _padding-right($secondValue);
+            @include _padding-left($firstValue);
+            @include _padding-right($secondValue);
+
+          } @else {
+
+            @include _when-left-to-right {
+              @include _padding-left($firstValue);
+              @include _padding-right($secondValue);
+            }
+
+            @include _when-right-to-left {
+              @include _padding-right($firstValue);
+              @include _padding-left($secondValue);
+            }
+
+          }
+        }
+
+        $derivedFirstValue: 0;
+        $derivedSecondValue: 0;
+        @if $firstValue != 0 {
+          $derivedFirstValue: #{get-rem-from-px($firstValue)}rem;
+        }
+        @if $secondValue != 0 {
+          $derivedSecondValue: #{get-rem-from-px($secondValue)}rem;
+        }
+
+        @if $firstValue == $secondValue {
+          #{$space_type}-inline: $derivedFirstValue;
+        } @else {
+          html[dir] & {
+            #{$space_type}-inline: $derivedFirstValue $derivedSecondValue;
+          }
+        }
 
       } @else {
+        @if $space_type == padding {
+          @include _padding-left($size_in_px);
+          @include _padding-right($size_in_px);
+        }
+        #{$space_type}-inline: #{get-rem-from-px($size_in_px)}rem;
 
+      }
+    }
+
+    @if $dimension == "inline-start" {
+      @if $size_in_px == 0 {
         @include _when-left-to-right {
-          @include _padding-left($firstValue);
-          @include _padding-right($secondValue);
+          #{$space_type}-left: 0;
         }
-
         @include _when-right-to-left {
-          @include _padding-right($firstValue);
-          @include _padding-left($secondValue);
+          #{$space_type}-right: 0;
         }
-
-      }
-
-      $derivedFirstValue: 0;
-      $derivedSecondValue: 0;
-      @if $firstValue != 0 {
-        $derivedFirstValue: #{get-rem-from-px($firstValue)}rem;
-      }
-      @if $secondValue != 0 {
-        $derivedSecondValue: #{get-rem-from-px($secondValue)}rem;
-      }
-      @if $firstValue == $secondValue {
-        padding-inline: $derivedFirstValue;
-      } @else {
         html[dir] & {
-          padding-inline: $derivedFirstValue $derivedSecondValue;
+          #{$space_type}-inline-start: 0;
+        }
+      } @else {
+        @include _when-left-to-right {
+          @if $space_type == padding {
+            @include _padding-left(nth($size_in_px, 1));
+          }
+        }
+        @include _when-right-to-left {
+          @if $space_type == padding {
+            @include _padding-right(nth($size_in_px, 1));
+          }
+        }
+        html[dir] & {
+          #{$space_type}-inline-start: #{get-rem-from-px(nth($size_in_px, 1))}rem;
         }
       }
-
-    } @else {
-      @include _padding-left($size_in_px);
-      @include _padding-right($size_in_px);
-      padding-inline: #{get-rem-from-px($size_in_px)}rem;
     }
-  }
 
-  @if $dimension == "inline-start" {
-    @if $size_in_px == 0 {
-      @include _when-left-to-right {
-        padding-left: 0;
-      }
-      @include _when-right-to-left {
-        padding-right: 0;
-      }
-      html[dir] & {
-        padding-inline-start: 0;
-      }
-    } @else {
-      @include _when-left-to-right {
-        @include _padding-left(nth($size_in_px, 1));
-      }
-      @include _when-right-to-left {
-        @include _padding-right(nth($size_in_px, 1));
-      }
-      html[dir] & {
-        padding-inline-start: #{get-rem-from-px(nth($size_in_px, 1))}rem;
-      }
-    }
-  }
-
-  @if $dimension == "inline-end" {
-    @if $size_in_px == 0 {
-      @include _when-left-to-right {
-        padding-right: 0;
-      }
-      @include _when-right-to-left {
-        padding-left: 0;
-      }
-      html[dir] & {
-        padding-inline-end: 0;
-      }
-    } @else {
-      @include _when-left-to-right {
-        @include _padding-right(nth($size_in_px, 1));
-      }
-      @include _when-right-to-left {
-        @include _padding-left(nth($size_in_px, 1));
-      }
-      html[dir] & {
-        padding-inline-end: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+    @if $dimension == "inline-end" {
+      @if $size_in_px == 0 {
+        @include _when-left-to-right {
+          #{$space_type}-right: 0;
+        }
+        @include _when-right-to-left {
+          #{$space_type}-left: 0;
+        }
+        html[dir] & {
+          #{$space_type}-inline-end: 0;
+        }
+      } @else {
+        @include _when-left-to-right {
+          @if $space_type == padding {
+            @include _padding-right(nth($size_in_px, 1));
+          }
+        }
+        @include _when-right-to-left {
+          @if $space_type == padding {
+            @include _padding-left(nth($size_in_px, 1));
+          }
+        }
+        html[dir] & {
+          #{$space_type}-inline-end: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+        }
       }
     }
-  }
 
-  // Vertical writing modes not yet supported
-  @if $dimension == "block" {
-    @if $size_in_px == 0 {
-      padding-top: 0;
-      padding-bottom: 0;
-      padding-block: 0;
+    // Vertical writing modes not yet supported
+    @if $dimension == "block" {
+      @if $size_in_px == 0 {
+        #{$space_type}-top: 0;
+        #{$space_type}-bottom: 0;
+        #{$space_type}-block: 0;
 
-    } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
-      padding-top: #{nth($size_in_px, 1)}px;
-      padding-top: #{get-rem-from-px(nth($size_in_px, 1))}rem;
-      padding-bottom: #{nth($size_in_px, 2)}px;
-      padding-bottom: #{get-rem-from-px(nth($size_in_px, 2))}rem;
-      padding-block: #{get-rem-from-px(nth($size_in_px, 1))}rem #{get-rem-from-px(nth($size_in_px, 2))}rem;;
+      } @else if type_of($size_in_px) == list and length($size_in_px) >= 2 {
+        #{$space_type}-top: #{nth($size_in_px, 1)}px;
+        #{$space_type}-top: #{get-rem-from-px(nth($size_in_px, 1))}rem;
+        #{$space_type}-bottom: #{nth($size_in_px, 2)}px;
+        #{$space_type}-bottom: #{get-rem-from-px(nth($size_in_px, 2))}rem;
+        #{$space_type}-block: #{get-rem-from-px(nth($size_in_px, 1))}rem #{get-rem-from-px(nth($size_in_px, 2))}rem;;
 
-    } @else {
-      padding-top: #{$size_in_px}px;
-      padding-top: #{get-rem-from-px($size_in_px)}rem;
-      padding-bottom: #{$size_in_px}px;
-      padding-bottom: #{get-rem-from-px($size_in_px)}rem;
-      padding-block: #{get-rem-from-px($size_in_px)}rem;
+      } @else {
+        #{$space_type}-top: #{$size_in_px}px;
+        #{$space_type}-top: #{get-rem-from-px($size_in_px)}rem;
+        #{$space_type}-bottom: #{$size_in_px}px;
+        #{$space_type}-bottom: #{get-rem-from-px($size_in_px)}rem;
+        #{$space_type}-block: #{get-rem-from-px($size_in_px)}rem;
+      }
     }
   }
+}
+
+@mixin padding($size_in_px, $dimension: "") {
+  @include _spacing($size_in_px, padding, $dimension);
 
 }
 

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -56,7 +56,7 @@
 //
 //</div>
 @mixin _spacing($size_in_px, $space_type, $dimension: "") {
-  @if $space_type != padding {
+  @if $space_type != padding and $space_type != margin {
     // This is for padding only
   } @else {
     @if $dimension == "" {
@@ -201,42 +201,7 @@
 }
 
 @mixin margin($size_in_px, $dimension: "") {
-  @if $dimension == top or $dimension == right or $dimension == bottom or $dimension == left {
-    @if $size_in_px == 0 {
-      margin-#{$dimension}: 0;
-    } @else {
-      margin-#{$dimension}: #{$size_in_px}px;
-      margin-#{$dimension}: #{get-rem-from-px($size_in_px)}rem;
-    }
-  }
-  @else if $dimension == "" and type_of($size_in_px) == list {
-    $parts-px: ();
-    $parts-rem: ();
-    @each $size in $size_in_px {
-      @if $size == 0 {
-        $parts-px: append($parts-px, 0, "space");
-      } @else {
-        $parts-px: append($parts-px, #{$size}px, "space");
-      }
-    }
-    @each $size in $size_in_px {
-      @if $size == 0 {
-        $parts-rem: append($parts-rem, 0, "space");
-      } @else {
-        $parts-rem: append($parts-rem, #{get-rem-from-px($size)}rem, "space");
-      }
-    }
-    margin: $parts-px;
-    margin: $parts-rem;
-  }
-  @else {
-    @if $size_in_px == 0 {
-      margin: 0;
-    } @else {
-      margin: #{$size_in_px}px;
-      margin: #{get-rem-from-px($size_in_px)}rem;
-    }
-  }
+  @include _spacing($size_in_px, margin, $dimension);
 }
 
 @mixin nospace($dimension: "all") {

--- a/source/css/sass/_mixins--spacing.scss
+++ b/source/css/sass/_mixins--spacing.scss
@@ -205,7 +205,7 @@
 }
 
 @mixin nospace($dimension: "all") {
-  $allowed-dimensions: "inline", "inline-start", "inline-end";
+  $allowed-dimensions: "inline", "inline-start", "inline-end", "block";
   @if index($allowed-dimensions, $dimension) != null {
     @include margin(0, $dimension);
     @include padding(0, $dimension);

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -20,6 +20,10 @@
     @return _error("More than two sizes supplied (with 'inline' dimension)", $capture-errors);
   }
 
+  @if $dimension == "inline-start" and length($sizes-in-px) > 1 {
+    @return _error("More than one size supplied (with 'inline-start' dimension)", $capture-errors);
+  }
+
   @return "OK";
 
 }

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -2,7 +2,24 @@
 
 @import "variables--typography";
 
+@function _error($message, $capture: false) {
+  @if $capture {
+    @return "ERROR: #{$message}";
+  }
+
+  @error "#{$message}";
+}
+
+@function validate-spacing-arguments($sizes-in-px, $dimension: "", $capture-errors: false) {
+
+  @if $dimension == "" and  length($sizes-in-px) > 4 {
+    @return _error("More than four sizes supplied (with no dimension)", $capture-errors);
+  }
+
+  @return "OK";
+
+}
+
 @function get-rem-from-px($size_in_px) {
   @return $size_in_px/$libero-font-size-base-in-px;
 }
-

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -28,6 +28,10 @@
     @return _error("More than one size supplied (with 'inline-end' dimension)", $capture-errors);
   }
 
+  @if $dimension == "block" and length($sizes-in-px) > 2 {
+    @return _error("More than two sizes supplied (with 'block' dimension)", $capture-errors);
+  }
+
   @return "OK";
 
 }

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -10,7 +10,11 @@
   @error "#{$message}";
 }
 
-@function validate-spacing-arguments($sizes-in-px, $dimension: "", $capture-errors: false) {
+@function validate-spacing-arguments($sizes-in-px, $space-type, $dimension: "", $capture-errors: false) {
+
+  @if $space-type != "padding" and $space-type != "margin" {
+    @return _error("Incorrect space-type supplied (must be either 'margin' or 'padding'", $capture-errors);
+  }
 
   @if $dimension == "" and length($sizes-in-px) > 4 {
     @return _error("More than four sizes supplied (with no dimension)", $capture-errors);

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -24,6 +24,10 @@
     @return _error("More than one size supplied (with 'inline-start' dimension)", $capture-errors);
   }
 
+  @if $dimension == "inline-end" and length($sizes-in-px) > 1 {
+    @return _error("More than one size supplied (with 'inline-end' dimension)", $capture-errors);
+  }
+
   @return "OK";
 
 }

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -36,6 +36,10 @@
     @return _error("More than two sizes supplied (with 'block' dimension)", $capture-errors);
   }
 
+  @if $dimension == "block-start" and length($sizes-in-px) > 1 {
+    @return _error("More than one size supplied (with 'block-start' dimension)", $capture-errors);
+  }
+
   @return "OK";
 
 }

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -17,7 +17,7 @@
   }
 
   @if $dimension == "inline" and length($sizes-in-px) > 2 {
-    @return _error("More than three sizes supplied (with 'inline' dimension)", $capture-errors);
+    @return _error("More than two sizes supplied (with 'inline' dimension)", $capture-errors);
   }
 
   @return "OK";

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -40,6 +40,10 @@
     @return _error("More than one size supplied (with 'block-start' dimension)", $capture-errors);
   }
 
+  @if $dimension == "block-end" and length($sizes-in-px) > 1 {
+    @return _error("More than one size supplied (with 'block-end' dimension)", $capture-errors);
+  }
+
   @return "OK";
 
 }

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -12,8 +12,12 @@
 
 @function validate-spacing-arguments($sizes-in-px, $dimension: "", $capture-errors: false) {
 
-  @if $dimension == "" and  length($sizes-in-px) > 4 {
+  @if $dimension == "" and length($sizes-in-px) > 4 {
     @return _error("More than four sizes supplied (with no dimension)", $capture-errors);
+  }
+
+  @if $dimension == "inline" and length($sizes-in-px) > 2 {
+    @return _error("More than three sizes supplied (with 'inline' dimension)", $capture-errors);
   }
 
   @return "OK";

--- a/source/css/sass/_utility-functions.scss
+++ b/source/css/sass/_utility-functions.scss
@@ -13,35 +13,35 @@
 @function validate-spacing-arguments($sizes-in-px, $space-type, $dimension: "", $capture-errors: false) {
 
   @if $space-type != "padding" and $space-type != "margin" {
-    @return _error("Incorrect space-type supplied (must be either 'margin' or 'padding'", $capture-errors);
+    @return _error("Incorrect space-type supplied: must be either 'margin' or 'padding'", $capture-errors);
   }
 
   @if $dimension == "" and length($sizes-in-px) > 4 {
-    @return _error("More than four sizes supplied (with no dimension)", $capture-errors);
+    @return _error("More than four sizes supplied when no dimension", $capture-errors);
   }
 
   @if $dimension == "inline" and length($sizes-in-px) > 2 {
-    @return _error("More than two sizes supplied (with 'inline' dimension)", $capture-errors);
+    @return _error("More than two sizes supplied with 'inline' dimension", $capture-errors);
   }
 
   @if $dimension == "inline-start" and length($sizes-in-px) > 1 {
-    @return _error("More than one size supplied (with 'inline-start' dimension)", $capture-errors);
+    @return _error("More than one size supplied with 'inline-start' dimension", $capture-errors);
   }
 
   @if $dimension == "inline-end" and length($sizes-in-px) > 1 {
-    @return _error("More than one size supplied (with 'inline-end' dimension)", $capture-errors);
+    @return _error("More than one size supplied with 'inline-end' dimension", $capture-errors);
   }
 
   @if $dimension == "block" and length($sizes-in-px) > 2 {
-    @return _error("More than two sizes supplied (with 'block' dimension)", $capture-errors);
+    @return _error("More than two sizes supplied with 'block' dimension", $capture-errors);
   }
 
   @if $dimension == "block-start" and length($sizes-in-px) > 1 {
-    @return _error("More than one size supplied (with 'block-start' dimension)", $capture-errors);
+    @return _error("More than one size supplied with 'block-start' dimension", $capture-errors);
   }
 
   @if $dimension == "block-end" and length($sizes-in-px) > 1 {
-    @return _error("More than one size supplied (with 'block-end' dimension)", $capture-errors);
+    @return _error("More than one size supplied with 'block-end' dimension", $capture-errors);
   }
 
   @return "OK";

--- a/test/sass/_variables_test.scss
+++ b/test/sass/_variables_test.scss
@@ -1,0 +1,1 @@
+$_is_test-environment: true;

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -32,6 +32,147 @@
     }
   }
 
+  @include it("generates correct fallbacks with a pair of non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(32 48);
+      }
+
+      @include expect {
+        padding: 32px 48px;
+        padding: 2rem 3rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with three non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(32 48 64);
+      }
+
+      @include expect {
+        padding: 32px 48px 64px;
+        padding: 2rem 3rem 4rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with one zero and one non-zero value and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(0 48);
+      }
+
+      @include expect {
+        padding: 0 48px;
+        padding: 0 3rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(48 0);
+      }
+
+      @include expect {
+        padding: 48px 0;
+        padding: 3rem 0;
+      }
+
+    }
+
+  }
+
+  @include it("generates correct fallbacks with in total three zero and/or non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(0 48 128);
+      }
+
+      @include expect {
+        padding: 0 48px 128px;
+        padding: 0 3rem 8rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(48 0 128);
+      }
+
+      @include expect {
+        padding: 48px 0 128px;
+        padding: 3rem 0 8rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(48 128 0);
+      }
+
+      @include expect {
+        padding: 48px 128px 0;
+        padding: 3rem 8rem 0;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(0 0 0);
+      }
+
+      @include expect {
+        padding: 0 0 0;
+      }
+
+    }
+
+  }
+
+  @include it("generates correct fallbacks with in total four zero and/or non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include padding(0 48 128 256);
+      }
+
+      @include expect {
+        padding: 0 48px 128px 256px;
+        padding: 0 3rem 8rem 16rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include padding(0 0 0 0);
+      }
+
+      @include expect {
+        padding: 0 0 0 0;
+      }
+
+    }
+
+  }
+
   @include it("generates correct fallbacks with a single zero value for dimension 'inline'") {
     @include assert() {
 
@@ -176,89 +317,89 @@
         padding-left: 0;
         padding-right: 0;
         padding-inline: 0;
-        }
+      }
 
     }
   }
 
   @include it("Ignores more than two values in the sizes list for the dimension 'inline'") {
-      @include assert() {
+    @include assert() {
 
-        @include output {
-          @include padding(16 32 48, "inline");
+      @include output {
+        @include padding(16 32 48, "inline");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+          padding-right: 32px;
+          padding-right: 2rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+          padding-left: 32px;
+          padding-left: 2rem;
         }
 
-        @include expect {
-          html[dir="ltr"] &:not([dir]),
-          &[dir="ltr"] {
-            padding-left: 16px;
-            padding-left: 1rem;
-            padding-right: 32px;
-            padding-right: 2rem;
-          }
-          html[dir="rtl"] &:not([dir]),
-          &[dir="rtl"] {
-            padding-right: 16px;
-            padding-right: 1rem;
-            padding-left: 32px;
-            padding-left: 2rem;
-          }
-
-          html[dir] & {
-            padding-inline: 1rem 2rem;
-          }
+        html[dir] & {
+          padding-inline: 1rem 2rem;
         }
       }
     }
+  }
 
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
-   @include assert() {
+    @include assert() {
 
-     @include output {
-       @include padding(0, "inline-start");
-     }
+      @include output {
+        @include padding(0, "inline-start");
+      }
 
-     @include expect {
-       html[dir="ltr"] &:not([dir]),
-       &[dir="ltr"] {
-         padding-left: 0;
-       }
-       html[dir="rtl"] &:not([dir]),
-       &[dir="rtl"] {
-         padding-right: 0;
-       }
-       html[dir] & {
-        padding-inline-start: 0;
-       }
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 0;
+        }
+        html[dir] & {
+          padding-inline-start: 0;
+        }
 
-   }
+      }
+    }
   }
-}
 
   @include it("generates correct fallbacks with a single non-zero value for the dimension 'inline-start'") {
-   @include assert() {
+    @include assert() {
 
-     @include output {
-       @include padding(16, "inline-start");
-     }
+      @include output {
+        @include padding(16, "inline-start");
+      }
 
-     @include expect {
-       html[dir="ltr"] &:not([dir]),
-       &[dir="ltr"] {
-         padding-left: 16px;
-         padding-left: 1rem;
-       }
-       html[dir="rtl"] &:not([dir]),
-       &[dir="rtl"] {
-         padding-right: 16px;
-         padding-right: 1rem;
-       }
-       html[dir] & {
-        padding-inline-start: 1rem;
-       }
-     }
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        html[dir] & {
+          padding-inline-start: 1rem;
+        }
+      }
+    }
   }
-}
 
   @include it("Ignores more than one value in the sizes list for the dimension 'inline-start'") {
     @include assert() {
@@ -290,17 +431,17 @@
     @include assert() {
 
       @include output {
-       @include padding(0, "inline-end");
+        @include padding(0, "inline-end");
       }
 
       @include expect {
         html[dir="ltr"] &:not([dir]),
         &[dir="ltr"] {
-         padding-right: 0;
+          padding-right: 0;
         }
         html[dir="rtl"] &:not([dir]),
         &[dir="rtl"] {
-         padding-left: 0;
+          padding-left: 0;
         }
         html[dir] & {
           padding-inline-end: 0;
@@ -313,28 +454,27 @@
   @include it("generates correct fallbacks with a single non-zero value for the dimension 'inline-end'") {
     @include assert() {
 
-     @include output {
-       @include padding(16, "inline-end");
-     }
+      @include output {
+        @include padding(16, "inline-end");
+      }
 
-     @include expect {
-       html[dir="ltr"] &:not([dir]),
-       &[dir="ltr"] {
-         padding-right: 16px;
-         padding-right: 1rem;
-       }
-       html[dir="rtl"] &:not([dir]),
-       &[dir="rtl"] {
-         padding-left: 16px;
-         padding-left: 1rem;
-       }
-       html[dir] & {
-        padding-inline-end: 1rem;
-       }
-     }
-   }
-}
-
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-right: 16px;
+          padding-right: 1rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-left: 16px;
+          padding-left: 1rem;
+        }
+        html[dir] & {
+          padding-inline-end: 1rem;
+        }
+      }
+    }
+  }
 
   @include it("Ignores more than one value in the sizes list for the dimension 'inline-end'") {
     @include assert() {
@@ -424,15 +564,14 @@
       }
 
       @include expect {
-          padding-top: 16px;
-          padding-top: 1rem;
-          padding-bottom: 32px;
-          padding-bottom: 2rem;
-          padding-block: 1rem 2rem;
+        padding-top: 16px;
+        padding-top: 1rem;
+        padding-bottom: 32px;
+        padding-bottom: 2rem;
+        padding-block: 1rem 2rem;
       }
     }
   }
-
 }
 
 // Tests for margin spacing
@@ -465,6 +604,119 @@
       }
 
     }
+  }
+
+  @include it("generates correct fallbacks with a pair of non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include margin(32 48);
+      }
+
+      @include expect {
+        margin: 32px 48px;
+        margin: 2rem 3rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with one zero and one non-zero value and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include margin(0 48);
+      }
+
+      @include expect {
+        margin: 0 48px;
+        margin: 0 3rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(48 0);
+      }
+
+      @include expect {
+        margin: 48px 0;
+        margin: 3rem 0;
+      }
+
+    }
+
+  }
+
+  @include it("generates correct fallbacks with three non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include margin(32 48 64);
+      }
+
+      @include expect {
+        margin: 32px 48px 64px;
+        margin: 2rem 3rem 4rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with in total three zero and/or non-zero values and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include margin(0 48 128);
+      }
+
+      @include expect {
+        margin: 0 48px 128px;
+        margin: 0 3rem 8rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(48 0 128);
+      }
+
+      @include expect {
+        margin: 48px 0 128px;
+        margin: 3rem 0 8rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(48 128 0);
+      }
+
+      @include expect {
+        margin: 48px 128px 0;
+        margin: 3rem 8rem 0;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(0 0 0);
+      }
+
+      @include expect {
+        margin: 0 0 0;
+      }
+
+    }
+
   }
 
   @include it("generates correct fallbacks with a single zero value for dimension 'inline'") {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -1000,7 +1000,24 @@
 
     }
   }
-  //@include it("generates correct zeroing for the dimension 'block-end'");
+
+  @include it("generates correct zeroing for the dimension 'block-end'") {
+    @include assert() {
+
+      @include output {
+        @include nospace("block-end")
+      }
+
+      @include expect {
+        margin-bottom: 0;
+        margin-block-end: 0;
+        padding-bottom: 0;
+        padding-block-end: 0;
+      }
+
+    }
+  }
+
   //@include it("generates correct zeroing for the dimension 'all'");
   //@include it("generates correct zeroing for all dimensions when not supplied with any dimension");
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -892,4 +892,40 @@
     }
 
   }
+
+  @include it("generates correct zeroing for the dimension 'inline-start'") {
+    @include assert {
+
+      @include output {
+        @include nospace("inline-start");
+      }
+
+      @include expect {
+
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 0;
+        }
+        html[dir] & {
+          margin-inline-start: 0;
+        }
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-left: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-right: 0;
+        }
+        html[dir] & {
+          padding-inline-start: 0;
+        }
+      }
+
+    }
+  }
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -928,4 +928,39 @@
 
     }
   }
+
+  @include it("generates correct zeroing for the dimension 'inline-end'") {
+    @include assert {
+
+      @include output {
+        @include nospace("inline-end");
+      }
+
+      @include expect {
+
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-right: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-left: 0;
+        }
+        html[dir] & {
+          margin-inline-end: 0;
+        }
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          padding-right: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          padding-left: 0;
+        }
+        html[dir] & {
+          padding-inline-end: 0;
+        }
+      }
+    }
+  }
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -1018,6 +1018,18 @@
     }
   }
 
-  //@include it("generates correct zeroing for the dimension 'all'");
-  //@include it("generates correct zeroing for all dimensions when not supplied with any dimension");
+  @include it("generates correct zeroing for all dimensions when not supplied with any dimension") {
+    @include assert() {
+
+      @include output {
+        @include nospace()
+      }
+
+      @include expect {
+        margin: 0;
+        padding: 0;
+      }
+
+    }
+  }
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -372,32 +372,6 @@
     }
   }
 
-  @include it("Ignores more than one value in the sizes list for the dimension 'inline-start'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16 32, "inline-start");
-      }
-
-      @include expect {
-        html[dir="ltr"] &:not([dir]),
-        &[dir="ltr"] {
-          padding-left: 16px;
-          padding-left: 1rem;
-        }
-        html[dir="rtl"] &:not([dir]),
-        &[dir="rtl"] {
-          padding-right: 16px;
-          padding-right: 1rem;
-        }
-        html[dir] & {
-          padding-inline-start: 1rem;
-        }
-      }
-
-    }
-  }
-
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-end'") {
     @include assert() {
 
@@ -887,32 +861,6 @@
      }
   }
 }
-
-  @include it("Ignores more than one value in the sizes list for the dimension 'inline-start'") {
-    @include assert() {
-
-      @include output {
-        @include margin(16 32, "inline-start");
-      }
-
-      @include expect {
-        html[dir="ltr"] &:not([dir]),
-        &[dir="ltr"] {
-          margin-left: 16px;
-          margin-left: 1rem;
-        }
-        html[dir="rtl"] &:not([dir]),
-        &[dir="rtl"] {
-          margin-right: 16px;
-          margin-right: 1rem;
-        }
-        html[dir] & {
-          margin-inline-start: 1rem;
-        }
-      }
-
-    }
-  }
 
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-end'") {
     @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -983,7 +983,23 @@
     }
   }
 
-  //@include it("generates correct zeroing for the dimension 'block-start'");
+  // vertical writing modes not supported, so block-start always maps to top at the moment.
+  @include it("generates correct zeroing for the dimension 'block-start'") {
+    @include assert() {
+
+      @include output {
+        @include nospace("block-start")
+      }
+
+      @include expect {
+        margin-top: 0;
+        margin-block-start: 0;
+        padding-top: 0;
+        padding-block-start: 0;
+      }
+
+    }
+  }
   //@include it("generates correct zeroing for the dimension 'block-end'");
   //@include it("generates correct zeroing for the dimension 'all'");
   //@include it("generates correct zeroing for all dimensions when not supplied with any dimension");

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -475,22 +475,6 @@
     }
   }
 
-  @include it("Ignores more than two values in the sizes list for the dimension 'block'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16 32 48, "block");
-      }
-
-      @include expect {
-        padding-top: 16px;
-        padding-top: 1rem;
-        padding-bottom: 32px;
-        padding-bottom: 2rem;
-        padding-block: 1rem 2rem;
-      }
-    }
-  }
 }
 
 // Tests for margin spacing
@@ -940,22 +924,6 @@
     }
   }
 
-  @include it("Ignores more than two values in the sizes list for the dimension 'block'") {
-    @include assert() {
-
-      @include output {
-        @include margin(16 32 48, "block");
-      }
-
-      @include expect {
-          margin-top: 16px;
-          margin-top: 1rem;
-          margin-bottom: 32px;
-          margin-bottom: 2rem;
-          margin-block: 1rem 2rem;
-      }
-    }
-  }
 
 }
 

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -475,6 +475,38 @@
     }
   }
 
+  @include it("generates correct values for a single zero value and dimension 'block-start'") {
+    @include assert() {
+
+      @include output {
+        @include padding(0, "block-start")
+      }
+
+      @include expect {
+        padding-top: 0;
+        padding-block-start: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct values for a single non-zero value and dimension 'block-start'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "block-start")
+      }
+
+      @include expect {
+        padding-top: 16px;
+        padding-top: 1rem;
+
+        padding-block-start: 1rem;
+      }
+
+    }
+  }
+
 }
 
 @include describe("margin [Mixin]") {
@@ -923,6 +955,37 @@
     }
   }
 
+  @include it("generates correct values for a single zero value and dimension 'block-start'") {
+    @include assert() {
+
+      @include output {
+        @include margin(0, "block-start")
+      }
+
+      @include expect {
+        margin-top: 0;
+        margin-block-start: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct values for a single non-zero value and dimension 'block-start'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16, "block-start")
+      }
+
+      @include expect {
+        margin-top: 16px;
+        margin-top: 1rem;
+
+        margin-block-start: 1rem;
+      }
+
+    }
+  }
 
 }
 

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -963,4 +963,28 @@
       }
     }
   }
+
+  @include it("generates correct zeroing for the dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include nospace("block")
+      }
+
+      @include expect {
+        margin-top: 0;
+        margin-bottom: 0;
+        margin-block: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        padding-block: 0;
+      }
+
+    }
+  }
+
+  //@include it("generates correct zeroing for the dimension 'block-start'");
+  //@include it("generates correct zeroing for the dimension 'block-end'");
+  //@include it("generates correct zeroing for the dimension 'all'");
+  //@include it("generates correct zeroing for all dimensions when not supplied with any dimension");
 }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -434,3 +434,438 @@
   }
 
 }
+
+// Tests for margin spacing
+@include describe("margin [Mixin]") {
+
+  @include it("generates correct fallbacks with a single zero value and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include margin(0);
+      }
+
+      @include expect {
+        margin: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single non-zero value and no dimension") {
+    @include assert() {
+
+      @include output {
+        @include margin(16);
+      }
+
+      @include expect {
+        margin: 16px;
+        margin: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single zero value for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include margin(0, "inline");
+      }
+
+      @include expect {
+        margin-left: 0;
+        margin-right: 0;
+        margin-inline: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single non-zero value for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16, "inline");
+      }
+
+      @include expect {
+        margin-left: 16px;
+        margin-left: 1rem;
+        margin-right: 16px;
+        margin-right: 1rem;
+        margin-inline: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a pair of values for dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16 32, "inline");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 16px;
+          margin-left: 1rem;
+          margin-right: 32px;
+          margin-right: 2rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 16px;
+          margin-right: 1rem;
+          margin-left: 32px;
+          margin-left: 2rem;
+        }
+
+        html[dir] & {
+          margin-inline: 1rem 2rem;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(16 16, "inline");
+      }
+
+      @include expect {
+        margin-left: 16px;
+        margin-left: 1rem;
+        margin-right: 16px;
+        margin-right: 1rem;
+        margin-inline: 1rem;
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(0 32, "inline");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 0;
+          margin-right: 32px;
+          margin-right: 2rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 0;
+          margin-left: 32px;
+          margin-left: 2rem;
+        }
+
+        html[dir] & {
+          margin-inline: 0 2rem;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(16 0, "inline");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 16px;
+          margin-left: 1rem;
+          margin-right: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 16px;
+          margin-right: 1rem;
+          margin-left: 0;
+        }
+
+        html[dir] & {
+          margin-inline: 1rem 0;
+        }
+      }
+
+    }
+
+    @include assert() {
+
+      @include output {
+        @include margin(0 0, "inline");
+      }
+
+      @include expect {
+        margin-left: 0;
+        margin-right: 0;
+        margin-inline: 0;
+        }
+
+    }
+  }
+
+  @include it("Ignores more than two values in the sizes list for the dimension 'inline'") {
+      @include assert() {
+
+        @include output {
+          @include margin(16 32 48, "inline");
+        }
+
+        @include expect {
+          html[dir="ltr"] &:not([dir]),
+          &[dir="ltr"] {
+            margin-left: 16px;
+            margin-left: 1rem;
+            margin-right: 32px;
+            margin-right: 2rem;
+          }
+          html[dir="rtl"] &:not([dir]),
+          &[dir="rtl"] {
+            margin-right: 16px;
+            margin-right: 1rem;
+            margin-left: 32px;
+            margin-left: 2rem;
+          }
+
+          html[dir] & {
+            margin-inline: 1rem 2rem;
+          }
+        }
+      }
+    }
+
+  @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
+   @include assert() {
+
+     @include output {
+       @include margin(0, "inline-start");
+     }
+
+     @include expect {
+       html[dir="ltr"] &:not([dir]),
+       &[dir="ltr"] {
+         margin-left: 0;
+       }
+       html[dir="rtl"] &:not([dir]),
+       &[dir="rtl"] {
+         margin-right: 0;
+       }
+       html[dir] & {
+        margin-inline-start: 0;
+       }
+
+   }
+  }
+}
+
+  @include it("generates correct fallbacks with a single non-zero value for the dimension 'inline-start'") {
+   @include assert() {
+
+     @include output {
+       @include margin(16, "inline-start");
+     }
+
+     @include expect {
+       html[dir="ltr"] &:not([dir]),
+       &[dir="ltr"] {
+         margin-left: 16px;
+         margin-left: 1rem;
+       }
+       html[dir="rtl"] &:not([dir]),
+       &[dir="rtl"] {
+         margin-right: 16px;
+         margin-right: 1rem;
+       }
+       html[dir] & {
+        margin-inline-start: 1rem;
+       }
+     }
+  }
+}
+
+  @include it("Ignores more than one value in the sizes list for the dimension 'inline-start'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16 32, "inline-start");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-left: 16px;
+          margin-left: 1rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-right: 16px;
+          margin-right: 1rem;
+        }
+        html[dir] & {
+          margin-inline-start: 1rem;
+        }
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single zero value for the dimension 'inline-end'") {
+    @include assert() {
+
+      @include output {
+       @include margin(0, "inline-end");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+         margin-right: 0;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+         margin-left: 0;
+        }
+        html[dir] & {
+          margin-inline-end: 0;
+        }
+
+      }
+    }
+  }
+
+  @include it("generates correct fallbacks with a single non-zero value for the dimension 'inline-end'") {
+    @include assert() {
+
+     @include output {
+       @include margin(16, "inline-end");
+     }
+
+     @include expect {
+       html[dir="ltr"] &:not([dir]),
+       &[dir="ltr"] {
+         margin-right: 16px;
+         margin-right: 1rem;
+       }
+       html[dir="rtl"] &:not([dir]),
+       &[dir="rtl"] {
+         margin-left: 16px;
+         margin-left: 1rem;
+       }
+       html[dir] & {
+        margin-inline-end: 1rem;
+       }
+     }
+   }
+}
+
+
+  @include it("Ignores more than one value in the sizes list for the dimension 'inline-end'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16 32, "inline-end");
+      }
+
+      @include expect {
+        html[dir="ltr"] &:not([dir]),
+        &[dir="ltr"] {
+          margin-right: 16px;
+          margin-right: 1rem;
+        }
+        html[dir="rtl"] &:not([dir]),
+        &[dir="rtl"] {
+          margin-left: 16px;
+          margin-left: 1rem;
+        }
+        html[dir] & {
+          margin-inline-end: 1rem;
+        }
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single zero value for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include margin(0, "block")
+      }
+
+      @include expect {
+        margin-top: 0;
+        margin-bottom: 0;
+        margin-block: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct fallbacks with a single non-zero value for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16, "block")
+      }
+
+      @include expect {
+        margin-top: 16px;
+        margin-top: 1rem;
+        margin-bottom: 16px;
+        margin-bottom: 1rem;
+        margin-block: 1rem;
+      }
+
+    }
+  }
+
+  // Vertical writing modes not yet supported
+  @include it("generates correct fallbacks with a pair of non-zero values for dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16 32, "block")
+      }
+
+      @include expect {
+        margin-top: 16px;
+        margin-top: 1rem;
+        margin-bottom: 32px;
+        margin-bottom: 2rem;
+
+        margin-block: 1rem 2rem;
+      }
+
+    }
+  }
+
+  @include it("Ignores more than two values in the sizes list for the dimension 'block'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16 32 48, "block");
+      }
+
+      @include expect {
+          margin-top: 16px;
+          margin-top: 1rem;
+          margin-bottom: 32px;
+          margin-bottom: 2rem;
+          margin-block: 1rem 2rem;
+      }
+    }
+  }
+
+}

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -477,7 +477,6 @@
 
 }
 
-// Tests for margin spacing
 @include describe("margin [Mixin]") {
 
   @include it("generates correct fallbacks with a single zero value and no dimension") {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -322,35 +322,6 @@
     }
   }
 
-  @include it("Ignores more than two values in the sizes list for the dimension 'inline'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16 32 48, "inline");
-      }
-
-      @include expect {
-        html[dir="ltr"] &:not([dir]),
-        &[dir="ltr"] {
-          padding-left: 16px;
-          padding-left: 1rem;
-          padding-right: 32px;
-          padding-right: 2rem;
-        }
-        html[dir="rtl"] &:not([dir]),
-        &[dir="rtl"] {
-          padding-right: 16px;
-          padding-right: 1rem;
-          padding-left: 32px;
-          padding-left: 2rem;
-        }
-
-        html[dir] & {
-          padding-inline: 1rem 2rem;
-        }
-      }
-    }
-  }
 
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
     @include assert() {
@@ -867,36 +838,6 @@
 
     }
   }
-
-  @include it("Ignores more than two values in the sizes list for the dimension 'inline'") {
-      @include assert() {
-
-        @include output {
-          @include margin(16 32 48, "inline");
-        }
-
-        @include expect {
-          html[dir="ltr"] &:not([dir]),
-          &[dir="ltr"] {
-            margin-left: 16px;
-            margin-left: 1rem;
-            margin-right: 32px;
-            margin-right: 2rem;
-          }
-          html[dir="rtl"] &:not([dir]),
-          &[dir="rtl"] {
-            margin-right: 16px;
-            margin-right: 1rem;
-            margin-left: 32px;
-            margin-left: 2rem;
-          }
-
-          html[dir] & {
-            margin-inline: 1rem 2rem;
-          }
-        }
-      }
-    }
 
   @include it("generates correct fallbacks with a single zero value for the dimension 'inline-start'") {
    @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -507,6 +507,38 @@
     }
   }
 
+  @include it("generates correct values for a single zero value and dimension 'block-end'") {
+    @include assert() {
+
+      @include output {
+        @include padding(0, "block-end")
+      }
+
+      @include expect {
+        padding-bottom: 0;
+        padding-block-end: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct values for a single non-zero value and dimension 'block-end'") {
+    @include assert() {
+
+      @include output {
+        @include padding(16, "block-end")
+      }
+
+      @include expect {
+        padding-bottom: 16px;
+        padding-bottom: 1rem;
+
+        padding-block-end: 1rem;
+      }
+
+    }
+  }
+
 }
 
 @include describe("margin [Mixin]") {
@@ -982,6 +1014,38 @@
         margin-top: 1rem;
 
         margin-block-start: 1rem;
+      }
+
+    }
+  }
+
+  @include it("generates correct values for a single zero value and dimension 'block-end'") {
+    @include assert() {
+
+      @include output {
+        @include margin(0, "block-end")
+      }
+
+      @include expect {
+        margin-bottom: 0;
+        margin-block-end: 0;
+      }
+
+    }
+  }
+
+  @include it("generates correct values for a single non-zero value and dimension 'block-end'") {
+    @include assert() {
+
+      @include output {
+        @include margin(16, "block-end")
+      }
+
+      @include expect {
+        margin-bottom: 16px;
+        margin-bottom: 1rem;
+
+        margin-block-end: 1rem;
       }
 
     }

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -421,32 +421,6 @@
     }
   }
 
-  @include it("Ignores more than one value in the sizes list for the dimension 'inline-end'") {
-    @include assert() {
-
-      @include output {
-        @include padding(16 32, "inline-end");
-      }
-
-      @include expect {
-        html[dir="ltr"] &:not([dir]),
-        &[dir="ltr"] {
-          padding-right: 16px;
-          padding-right: 1rem;
-        }
-        html[dir="rtl"] &:not([dir]),
-        &[dir="rtl"] {
-          padding-left: 16px;
-          padding-left: 1rem;
-        }
-        html[dir] & {
-          padding-inline-end: 1rem;
-        }
-      }
-
-    }
-  }
-
   @include it("generates correct fallbacks with a single zero value for dimension 'block'") {
     @include assert() {
 
@@ -911,32 +885,6 @@
    }
 }
 
-
-  @include it("Ignores more than one value in the sizes list for the dimension 'inline-end'") {
-    @include assert() {
-
-      @include output {
-        @include margin(16 32, "inline-end");
-      }
-
-      @include expect {
-        html[dir="ltr"] &:not([dir]),
-        &[dir="ltr"] {
-          margin-right: 16px;
-          margin-right: 1rem;
-        }
-        html[dir="rtl"] &:not([dir]),
-        &[dir="rtl"] {
-          margin-left: 16px;
-          margin-left: 1rem;
-        }
-        html[dir] & {
-          margin-inline-end: 1rem;
-        }
-      }
-
-    }
-  }
 
   @include it("generates correct fallbacks with a single zero value for dimension 'block'") {
     @include assert() {

--- a/test/sass/mixins--spacing.spec.scss
+++ b/test/sass/mixins--spacing.spec.scss
@@ -869,3 +869,27 @@
   }
 
 }
+
+@include describe("nospace [Mixin]") {
+
+  @include it("generates correct zeroing for the dimension 'inline'") {
+    @include assert() {
+
+      @include output {
+        @include nospace("inline");
+      }
+
+      @include expect {
+        margin-left: 0;
+        margin-right: 0;
+        margin-inline: 0;
+        padding-left: 0;
+        padding-right: 0;
+        padding-inline: 0;
+
+      }
+
+    }
+
+  }
+}

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -141,6 +141,18 @@
 
   }
 
+  @include test("errors when 2 sizes values passed with dimension 'block-start'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "margin", "block-start", $_is_test-environment),
+            "ERROR: More than one size supplied (with 'block-start' dimension)"
+    );
+  }
 
+  @include test("does not error when 1 size value passed with dimension 'block-start'") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "margin", "block-start", $_is_test-environment),
+            "OK"
+    );
+  }
 
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -67,5 +67,11 @@
     );
   }
 
+  @include test("errors when 2 sizes values passed with dimension 'inline-end'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "inline-end", $_is_test-environment),
+            "ERROR: More than one size supplied (with 'inline-end' dimension)"
+    );
+  }
 
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -56,9 +56,8 @@
   @include test("errors when 3 sizes values passed with dimension 'inline'") {
     @include assert-equal(
             validate-spacing-arguments((1 2 3), "inline", $_is_test-environment),
-            "ERROR: More than three sizes supplied (with 'inline' dimension)"
+            "ERROR: More than two sizes supplied (with 'inline' dimension)"
     );
   }
-
 
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -155,4 +155,18 @@
     );
   }
 
+  @include test("errors when 2 sizes values passed with dimension 'block-end'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "margin", "block-end", $_is_test-environment),
+            "ERROR: More than one size supplied (with 'block-end' dimension)"
+    );
+  }
+
+  @include test("does not error when 1 size value passed with dimension 'block-end'") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "margin", "block-end", $_is_test-environment),
+            "OK"
+    );
+  }
+
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -23,31 +23,52 @@
 
 @include test-module("validate-spacing-arguments [Function]") {
 
+  @include test("errors when the space-type is neither margin nor padding") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "not-margin-nor-padding", "", $_is_test-environment),
+            "ERROR: Incorrect space-type supplied (must be either 'margin' or 'padding'"
+    );
+  }
+
+  @include test("does not error when the space-type is padding") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "padding", "", $_is_test-environment),
+            "OK"
+    );
+  }
+
+  @include test("does not error when the space-type is margin") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "margin", "", $_is_test-environment),
+            "OK"
+    );
+  }
+
   @include test("errors when 5 sizes values passed and no dimension") {
     @include assert-equal(
-            validate-spacing-arguments((1 2 3 4 5), "", $_is_test-environment),
+            validate-spacing-arguments((1 2 3 4 5), "margin", "", $_is_test-environment),
             "ERROR: More than four sizes supplied (with no dimension)"
     );
   }
 
   @include test("does not error when < 5 sizes values passed and no dimension") {
     @include assert-equal(
-            validate-spacing-arguments((1 2 3 4), "", $_is_test-environment),
+            validate-spacing-arguments((1 2 3 4), "margin", "", $_is_test-environment),
             "OK"
     );
 
     @include assert-equal(
-            validate-spacing-arguments((1 2 3), "", $_is_test-environment),
+            validate-spacing-arguments((1 2 3), "margin", "", $_is_test-environment),
             "OK"
     );
 
     @include assert-equal(
-            validate-spacing-arguments((1 2), "", $_is_test-environment),
+            validate-spacing-arguments((1 2), "margin", "", $_is_test-environment),
             "OK"
     );
 
     @include assert-equal(
-            validate-spacing-arguments((1), "", $_is_test-environment),
+            validate-spacing-arguments((1), "margin", "", $_is_test-environment),
             "OK"
     );
 
@@ -55,66 +76,66 @@
 
   @include test("errors when 3 sizes values passed with dimension 'inline'") {
     @include assert-equal(
-            validate-spacing-arguments((1 2 3), "inline", $_is_test-environment),
+            validate-spacing-arguments((1 2 3), "margin", "inline", $_is_test-environment),
             "ERROR: More than two sizes supplied (with 'inline' dimension)"
     );
   }
 
   @include test("does not error when < 3 sizes values passed with dimension 'inline'") {
     @include assert-equal(
-            validate-spacing-arguments((1 2), "inline", $_is_test-environment),
+            validate-spacing-arguments((1 2), "margin", "inline", $_is_test-environment),
             "OK"
     );
 
     @include assert-equal(
-            validate-spacing-arguments((1), "inline", $_is_test-environment),
+            validate-spacing-arguments((1), "margin", "inline", $_is_test-environment),
             "OK"
     );
   }
 
   @include test("errors when 2 sizes values passed with dimension 'inline-start'") {
     @include assert-equal(
-            validate-spacing-arguments((1 2), "inline-start", $_is_test-environment),
+            validate-spacing-arguments((1 2), "margin", "inline-start", $_is_test-environment),
             "ERROR: More than one size supplied (with 'inline-start' dimension)"
     );
   }
 
   @include test("does not error when 1 size value passed with dimension 'inline-start'") {
     @include assert-equal(
-            validate-spacing-arguments((1), "inline-start", $_is_test-environment),
+            validate-spacing-arguments((1), "margin", "inline-start", $_is_test-environment),
             "OK"
     );
   }
 
   @include test("errors when 2 sizes values passed with dimension 'inline-end'") {
     @include assert-equal(
-            validate-spacing-arguments((1 2), "inline-end", $_is_test-environment),
+            validate-spacing-arguments((1 2), "margin", "inline-end", $_is_test-environment),
             "ERROR: More than one size supplied (with 'inline-end' dimension)"
     );
   }
 
   @include test("does not error when 1 size value passed with dimension 'inline-end'") {
     @include assert-equal(
-            validate-spacing-arguments((1), "inline-start", $_is_test-environment),
+            validate-spacing-arguments((1), "margin", "inline-start", $_is_test-environment),
             "OK"
     );
   }
 
   @include test("errors when 3 sizes values passed with dimension 'block'") {
     @include assert-equal(
-            validate-spacing-arguments((1 2 3), "block", $_is_test-environment),
+            validate-spacing-arguments((1 2 3), "margin", "block", $_is_test-environment),
             "ERROR: More than two sizes supplied (with 'block' dimension)"
     );
   }
 
   @include test("does not errors when < 3 sizes values passed with dimension 'inline'") {
     @include assert-equal(
-            validate-spacing-arguments((1 2), "block", $_is_test-environment),
+            validate-spacing-arguments((1 2), "margin", "block", $_is_test-environment),
             "OK"
     );
 
     @include assert-equal(
-            validate-spacing-arguments((1), "block", $_is_test-environment),
+            validate-spacing-arguments((1), "margin", "block", $_is_test-environment),
             "OK"
     );
 

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -51,7 +51,14 @@
             "OK"
     );
 
-
   }
+
+  @include test("errors when 3 sizes values passed with dimension 'inline'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2 3), "inline", $_is_test-environment),
+            "ERROR: More than three sizes supplied (with 'inline' dimension)"
+    );
+  }
+
 
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -1,6 +1,8 @@
 @import "../../node_modules/sass-true/sass/true";
 @import "../../source/css/sass/_utility-functions.scss";
 
+@import "variables_test";
+
 @include test-module("the function get-rem-from-px [Function]") {
 
   @include test("returns 2 when supplied with 32") {
@@ -15,6 +17,41 @@
             get-rem-from-px(40),
             2.5
     );
+  }
+
+}
+
+@include test-module("validate-spacing-arguments [Function]") {
+
+  @include test("errors when 5 sizes values passed and no dimension") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2 3 4 5), "", $_is_test-environment),
+            "ERROR: More than four sizes supplied (with no dimension)"
+    );
+  }
+
+  @include test("does not error when < 5 sizes values passed and no dimension") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2 3 4), "", $_is_test-environment),
+            "OK"
+    );
+
+    @include assert-equal(
+            validate-spacing-arguments((1 2 3), "", $_is_test-environment),
+            "OK"
+    );
+
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "", $_is_test-environment),
+            "OK"
+    );
+
+    @include assert-equal(
+            validate-spacing-arguments((1), "", $_is_test-environment),
+            "OK"
+    );
+
+
   }
 
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -74,4 +74,11 @@
     );
   }
 
+  @include test("errors when 3 sizes values passed with dimension 'block'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2 3), "block", $_is_test-environment),
+            "ERROR: More than two sizes supplied (with 'block' dimension)"
+    );
+  }
+
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -60,4 +60,12 @@
     );
   }
 
+  @include test("errors when 2 sizes values passed with dimension 'inline-start'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "inline-start", $_is_test-environment),
+            "ERROR: More than one size supplied (with 'inline-start' dimension)"
+    );
+  }
+
+
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -60,10 +60,29 @@
     );
   }
 
+  @include test("does not error when < 3 sizes values passed with dimension 'inline'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "inline", $_is_test-environment),
+            "OK"
+    );
+
+    @include assert-equal(
+            validate-spacing-arguments((1), "inline", $_is_test-environment),
+            "OK"
+    );
+  }
+
   @include test("errors when 2 sizes values passed with dimension 'inline-start'") {
     @include assert-equal(
             validate-spacing-arguments((1 2), "inline-start", $_is_test-environment),
             "ERROR: More than one size supplied (with 'inline-start' dimension)"
+    );
+  }
+
+  @include test("does not error when 1 size value passed with dimension 'inline-start'") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "inline-start", $_is_test-environment),
+            "OK"
     );
   }
 
@@ -74,11 +93,33 @@
     );
   }
 
+  @include test("does not error when 1 size value passed with dimension 'inline-end'") {
+    @include assert-equal(
+            validate-spacing-arguments((1), "inline-start", $_is_test-environment),
+            "OK"
+    );
+  }
+
   @include test("errors when 3 sizes values passed with dimension 'block'") {
     @include assert-equal(
             validate-spacing-arguments((1 2 3), "block", $_is_test-environment),
             "ERROR: More than two sizes supplied (with 'block' dimension)"
     );
   }
+
+  @include test("does not errors when < 3 sizes values passed with dimension 'inline'") {
+    @include assert-equal(
+            validate-spacing-arguments((1 2), "block", $_is_test-environment),
+            "OK"
+    );
+
+    @include assert-equal(
+            validate-spacing-arguments((1), "block", $_is_test-environment),
+            "OK"
+    );
+
+  }
+
+
 
 }

--- a/test/sass/utility-functions.spec.scss
+++ b/test/sass/utility-functions.spec.scss
@@ -26,7 +26,7 @@
   @include test("errors when the space-type is neither margin nor padding") {
     @include assert-equal(
             validate-spacing-arguments((1), "not-margin-nor-padding", "", $_is_test-environment),
-            "ERROR: Incorrect space-type supplied (must be either 'margin' or 'padding'"
+            "ERROR: Incorrect space-type supplied: must be either 'margin' or 'padding'"
     );
   }
 
@@ -47,7 +47,7 @@
   @include test("errors when 5 sizes values passed and no dimension") {
     @include assert-equal(
             validate-spacing-arguments((1 2 3 4 5), "margin", "", $_is_test-environment),
-            "ERROR: More than four sizes supplied (with no dimension)"
+            "ERROR: More than four sizes supplied when no dimension"
     );
   }
 
@@ -77,7 +77,7 @@
   @include test("errors when 3 sizes values passed with dimension 'inline'") {
     @include assert-equal(
             validate-spacing-arguments((1 2 3), "margin", "inline", $_is_test-environment),
-            "ERROR: More than two sizes supplied (with 'inline' dimension)"
+            "ERROR: More than two sizes supplied with 'inline' dimension"
     );
   }
 
@@ -96,7 +96,7 @@
   @include test("errors when 2 sizes values passed with dimension 'inline-start'") {
     @include assert-equal(
             validate-spacing-arguments((1 2), "margin", "inline-start", $_is_test-environment),
-            "ERROR: More than one size supplied (with 'inline-start' dimension)"
+            "ERROR: More than one size supplied with 'inline-start' dimension"
     );
   }
 
@@ -110,7 +110,7 @@
   @include test("errors when 2 sizes values passed with dimension 'inline-end'") {
     @include assert-equal(
             validate-spacing-arguments((1 2), "margin", "inline-end", $_is_test-environment),
-            "ERROR: More than one size supplied (with 'inline-end' dimension)"
+            "ERROR: More than one size supplied with 'inline-end' dimension"
     );
   }
 
@@ -124,7 +124,7 @@
   @include test("errors when 3 sizes values passed with dimension 'block'") {
     @include assert-equal(
             validate-spacing-arguments((1 2 3), "margin", "block", $_is_test-environment),
-            "ERROR: More than two sizes supplied (with 'block' dimension)"
+            "ERROR: More than two sizes supplied with 'block' dimension"
     );
   }
 
@@ -144,7 +144,7 @@
   @include test("errors when 2 sizes values passed with dimension 'block-start'") {
     @include assert-equal(
             validate-spacing-arguments((1 2), "margin", "block-start", $_is_test-environment),
-            "ERROR: More than one size supplied (with 'block-start' dimension)"
+            "ERROR: More than one size supplied with 'block-start' dimension"
     );
   }
 
@@ -158,7 +158,7 @@
   @include test("errors when 2 sizes values passed with dimension 'block-end'") {
     @include assert-equal(
             validate-spacing-arguments((1 2), "margin", "block-end", $_is_test-environment),
-            "ERROR: More than one size supplied (with 'block-end' dimension)"
+            "ERROR: More than one size supplied with 'block-end' dimension"
     );
   }
 


### PR DESCRIPTION
1. Extract guts of `padding` mixin into internal `_spacing` mixin.
1. Rewrite `_padding-left` and `_padding-right` mixins to be `_spacing-left` and `_spacing-right`, respectively, in order to support both `padding` and `margin`.
1. Refactor `padding` mixin to be a thin wrapper calling `_spacing` with the `$space-type` of `padding`.
1. Write tests for `margin` mixin and implement using `_spacing` with the `$space-type` of `margin`.

Note: as we're not supporting vertical writing modes yet, `block-start` always sets `top`, and `block-end` always sets `bottom`.